### PR TITLE
Parameterize airtable base URL so that devs can point to alternate dataset

### DIFF
--- a/go/airtable.go
+++ b/go/airtable.go
@@ -6,7 +6,11 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 )
+
+var issuesTable = "Issues%20list"
+var contactsTable= "Contact"
 
 func refreshIssuesAndContacts() {
 	globalIssues, _ = fetchIssues()
@@ -80,7 +84,8 @@ func (i AirtableIssues) exportIssues() []Issue {
 }
 
 func fetchIssues() (AirtableIssues, error) {
-	url := "https://api.airtable.com/v0/app6dzsa26hDjI7tp/Issues%20list?filterByFormula=NOT(%7BInactive%7D)"
+	formula := url.QueryEscape("NOT({Inactive})")
+	url := fmt.Sprintf("%s/%s?filterByFormula=%s", *airtableUrl, issuesTable, formula)
 
 	client := http.DefaultClient
 	req, e := http.NewRequest("GET", url, nil)
@@ -114,7 +119,7 @@ type AirtableContact struct {
 }
 
 func fetchContacts() (AirtableContacts, error) {
-	url := "https://api.airtable.com/v0/app6dzsa26hDjI7tp/Contact"
+	url := fmt.Sprintf("%s/%s", *airtableUrl, contactsTable)
 
 	client := http.DefaultClient
 	req, e := http.NewRequest("GET", url, nil)

--- a/go/main.go
+++ b/go/main.go
@@ -20,6 +20,7 @@ import (
 var (
 	addr         = flag.String("addr", ":8090", "[ip]:port to listen on")
 	dbfile       = flag.String("dbfile", "fivecalls.db", "filename for sqlite db")
+	airtableUrl  = flag.String("db-url", "https://api.airtable.com/v0/app6dzsa26hDjI7tp", "base URL for airtable database")
 	airtableKey  = os.Getenv("AIRTABLE_API_KEY")
 	civicKey     = os.Getenv("CIVIC_API_KEY")
 	civicCache   = cache.New(1*time.Hour, 10*time.Minute)
@@ -156,7 +157,7 @@ func pageHandler(w http.ResponseWriter, r *http.Request) {
 					contact.Fields.Reason = "This is your local representative in the House"
 				}
 
-				newContacts = append(newContacts, contact)				
+				newContacts = append(newContacts, contact)
 			}
 		}
 


### PR DESCRIPTION
This allows for people to point to a personal/ test data set instead of the
production one. The production URL is still the default.