### PR TITLE
Backend improvements

### DIFF
--- a/go/admin.go
+++ b/go/admin.go
@@ -4,18 +4,20 @@ import (
 	"net/http"
 )
 
-func adminHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		http.Error(w, "GET only", 403)
-		return
-	}
-
+type cacheReloader interface {
+	Reload()
 }
 
-func adminRefreshHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(w, "POST only", 403)
-		return
-	}
+type adminHandler struct {
+	reloader cacheReloader
+}
 
+func (a *adminHandler) Stats(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Not implemented", http.StatusNotImplemented)
+}
+
+func (a *adminHandler) ReloadCache(w http.ResponseWriter, r *http.Request) {
+	a.reloader.Reload()
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write([]byte("cache reload message sent"))
 }

--- a/go/airtable.go
+++ b/go/airtable.go
@@ -35,7 +35,7 @@ type atIssueInfo struct {
 	Name         string   `json:"Name"`
 	Action       string   `json:"Action requested"`
 	Script       string   `json:"Script"`
-	ContactLinks []string `json:"contact"`
+	ContactLinks []string `json:"Contact"`
 }
 
 // atIssue is an airtable issue record.

--- a/go/civic.go
+++ b/go/civic.go
@@ -42,7 +42,9 @@ func (ae *APIError) Error() string {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%d %s", ae.Code, ae.Message)
 	for _, e := range ae.Errors {
-		fmt.Fprintf(&buf, ";[domain=%s, reason=%s: %s]", e.Domain, e.Reason, e.Message)
+		if e.Message != ae.Message { // don't duplicate messages
+			fmt.Fprintf(&buf, ";[domain=%s, reason=%s: %s]", e.Domain, e.Reason, e.Message)
+		}
 	}
 	return buf.String()
 }

--- a/go/civic.go
+++ b/go/civic.go
@@ -6,53 +6,187 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"bytes"
 	"github.com/patrickmn/go-cache"
+	"net/url"
+	"time"
 )
 
-// GoogleRepResponse is the whole response
-type GoogleRepResponse struct {
-	Offices   []GoogleOffice
-	Officials []GoogleOfficial
+const (
+	roleLowerBody = "legislatorLowerBody"
+	roleUpperBody = "legislatorUpperBody"
+	areaHouse     = "House"
+	areaSenate    = "Senate"
+)
+
+var baseURL = "https://www.googleapis.com/civicinfo/v2/representatives"
+
+// RepFinder provides a mechanism to find local reps given an address.
+type RepFinder interface {
+	GetReps(address string) (*LocalReps, *Address, error)
 }
 
-// GoogleOffice is an office in government
-type GoogleOffice struct {
-	Name            string
-	OfficialIndices []int
-}
-
-// GoogleOfficial is a local official
-type GoogleOfficial struct {
-	Name     string
-	Phones   []string
-	Urls     []string
-	PhotoURL string
-	Area     string
-}
-
-func getReps(zip string) (*GoogleRepResponse, error) {
-	if cacheReps, cacheFound := civicCache.Get(zip); cacheFound {
-		// log.Printf("got cached reps for %s",zip)
-
-		repResponse := cacheReps.(GoogleRepResponse)
-		return &repResponse, nil
-	} else {
-		// log.Printf("fetching new reps for %s",zip)
-		url := fmt.Sprintf("https://www.googleapis.com/civicinfo/v2/representatives?address=%s&fields=offices(name,officialIndices),officials(name,phones,urls,photoUrl)&levels=country&key=%s", zip, civicKey)
-
-		client := http.DefaultClient
-		r, e := client.Get(url)
-		defer r.Body.Close()
-		body, _ := ioutil.ReadAll(r.Body)
-		if r.StatusCode >= 200 && r.StatusCode <= 400 && e == nil {
-			parsedResponse := GoogleRepResponse{}
-			json.Unmarshal(body, &parsedResponse)
-
-			civicCache.Set(zip, parsedResponse, cache.DefaultExpiration)
-
-			return &parsedResponse, nil
-		}
-
-		return nil, fmt.Errorf("rep error code:%d error:%v body:%s", r.StatusCode, e, body)
+// APIError is an error returned by the Google civic API, which also
+// implements the error interface.
+type APIError struct {
+	Code    int
+	Message string
+	Errors  []struct {
+		Domain  string
+		Reason  string
+		Message string
 	}
+}
+
+func (ae *APIError) Error() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d %s", ae.Code, ae.Message)
+	for _, e := range ae.Errors {
+		fmt.Fprintf(&buf, ";[domain=%s, reason=%s: %s]", e.Domain, e.Reason, e.Message)
+	}
+	return buf.String()
+}
+
+// apiResponse is the response from the civic API. It encapsulates valid
+// responses that set the normalized input, offices and officials,
+// as well as error responses.
+type apiResponse struct {
+	NormalizedInput *Address
+	Offices         []struct {
+		Name            string
+		DivisionId      string
+		Levels          []string
+		Roles           []string
+		OfficialIndices []int
+	}
+	Officials []struct {
+		Name     string
+		Address  []Address
+		Party    string
+		Phones   []string
+		PhotoUrl string
+		Channels []struct {
+			Id   string
+			Type string
+		}
+	}
+	Error *APIError
+}
+
+// toLocalReps converts an API response to a set of local reps. In addition,
+// it also returns the normalized address for which the response is valid.
+func (r *apiResponse) toLocalReps() (*LocalReps, *Address, error) {
+	if r.Error != nil {
+		return nil, nil, r.Error
+	}
+	if len(r.Offices) == 0 {
+		return nil, nil, fmt.Errorf("no offices found ")
+	}
+	ret := &LocalReps{}
+	for _, o := range r.Offices {
+		for _, role := range o.Roles {
+			if role == roleUpperBody || role == roleLowerBody {
+				for _, i := range o.OfficialIndices {
+					official := r.Officials[i]
+					var phone string
+					if len(official.Phones) > 0 {
+						phone = official.Phones[0]
+					}
+					var area = areaHouse
+					if role == roleUpperBody {
+						area = areaSenate
+					}
+					c := &Contact{
+						Name:     official.Name,
+						Phone:    phone,
+						PhotoURL: official.PhotoUrl,
+						Area:     area,
+					}
+					if area == areaHouse {
+						ret.HouseRep = c
+					} else {
+						ret.Senators = append(ret.Senators, c)
+					}
+				}
+			}
+		}
+	}
+	return ret, r.NormalizedInput, nil
+}
+
+// civicAPI provides a semantic interface to the Google civic API.
+type civicAPI struct {
+	key string
+	c   *http.Client
+}
+
+// NewCivicAPI returns an instance of the civic API.
+func NewCivicAPI(key string, client *http.Client) RepFinder {
+	return &civicAPI{
+		key: key,
+		c:   client,
+	}
+}
+
+// GetReps returns local representatives for the supplied address.
+func (c *civicAPI) GetReps(address string) (*LocalReps, *Address, error) {
+	u := fmt.Sprintf("%s?key=%s&role=%s&role=%s&address=%s",
+		baseURL, c.key, roleUpperBody, roleLowerBody,
+		url.QueryEscape(address),
+	)
+	req, err := http.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	res, err := c.c.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer res.Body.Close()
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	var ar apiResponse
+	err = json.Unmarshal(b, &ar)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ar.toLocalReps()
+}
+
+// repCache implements a cache layer on top of a delegate rep finder.
+type repCache struct {
+	delegate RepFinder
+	cache    *cache.Cache
+}
+
+type cacheItem struct {
+	reps LocalReps
+	addr Address
+}
+
+func NewRepCache(delegate RepFinder, ttl time.Duration, gc time.Duration) RepFinder {
+	return &repCache{
+		delegate: delegate,
+		cache:    cache.New(ttl, gc),
+	}
+}
+
+// GetReps returns local representatives for the supplied address.
+func (r *repCache) GetReps(address string) (*LocalReps, *Address, error) {
+	data, ok := r.cache.Get(address)
+	if ok {
+		ci := data.(*cacheItem)
+		reps := ci.reps
+		addr := ci.addr
+		return &reps, &addr, nil
+	}
+	reps, addr, err := r.delegate.GetReps(address)
+	if err != nil {
+		return nil, nil, err
+	}
+	ci := &cacheItem{reps: *reps, addr: *addr}
+	r.cache.Set(address, ci, cache.DefaultExpiration)
+	return reps, addr, nil
 }

--- a/go/handler.go
+++ b/go/handler.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"github.com/gorilla/mux"
+	"log"
+	"net/http"
+)
+
+const localPlaceholder = "LOCAL REP"
+
+type handler struct {
+	repFinder   RepFinder
+	issueLister IssueLister
+}
+
+func (h *handler) GetIssues(w http.ResponseWriter, r *http.Request) {
+	var localReps *LocalReps
+	var err error
+	zip := mux.Vars(r)["zip"]
+
+	if len(zip) == 5 {
+		log.Printf("zip %s", zip)
+		localReps, _, err = h.repFinder.GetReps(zip)
+		if err != nil {
+			log.Println("Unable to find local reps for", zip, err)
+		}
+	} else {
+		log.Println("no zip")
+	}
+
+	// add local reps where necessary
+	customizedIssues := []Issue{}
+	all, err := h.issueLister.AllIssues()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	for _, issue := range all {
+		newContacts := []Contact{}
+		for _, contact := range issue.Contacts {
+			if contact.Name == localPlaceholder {
+				if localReps != nil {
+					if localReps.HouseRep != nil {
+						c := *localReps.HouseRep
+						c.Reason = "This is your local representative in the house"
+						newContacts = append(newContacts, c)
+					}
+					for _, s := range localReps.Senators {
+						c := *s
+						c.Reason = "This is one of your two senators"
+						newContacts = append(newContacts, c)
+					}
+				}
+			} else {
+				newContacts = append(newContacts, contact)
+			}
+		}
+		issue.Contacts = newContacts
+		customizedIssues = append(customizedIssues, issue)
+	}
+	writeJSON(w, customizedIssues)
+}

--- a/go/main.go
+++ b/go/main.go
@@ -5,41 +5,46 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/gorilla/mux"
+	_ "github.com/mattn/go-sqlite3"
 	"log"
 	"net/http"
 	"os"
 	"text/template"
 	"time"
-
-	"github.com/gorilla/mux"
-	_ "github.com/mattn/go-sqlite3"
-	"github.com/patrickmn/go-cache"
 )
-
-var (
-	addr         = flag.String("addr", ":8090", "[ip]:port to listen on")
-	dbfile       = flag.String("dbfile", "fivecalls.db", "filename for sqlite db")
-	airtableBase = flag.String("airtable-base", "app6dzsa26hDjI7tp", "base ID for airtable store")
-	airtableKey  = os.Getenv("AIRTABLE_API_KEY")
-	civicKey     = os.Getenv("CIVIC_API_KEY")
-
-	db         *sql.DB
-	countCache = cache.New(1*time.Hour, 10*time.Minute)
-)
-
-var globalIssues IssueLister
-var repFinder RepFinder
 
 var pagetemplate *template.Template
 
+func writeJSON(w http.ResponseWriter, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Println("[WARN]", err)
+	}
+}
+
+func enableCORS(fn http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		fn(w, r)
+	}
+}
+
 func main() {
+
+	dbfile := flag.String("dbfile", "fivecalls.db", "filename for sqlite db")
+	airtableBase := flag.String("airtable-base", "app6dzsa26hDjI7tp", "base ID for airtable store")
+	addr := flag.String("addr", ":8090", "[ip]:port to listen on")
+	airtableKey := os.Getenv("AIRTABLE_API_KEY")
+	civicKey := os.Getenv("CIVIC_API_KEY")
+
 	flag.Parse()
 
 	if airtableKey == "" {
-		log.Fatal("No airtable API key found")
+		log.Fatalln("No airtable API key found")
 	}
 	if civicKey == "" {
-		log.Fatal("No google civic API key found")
+		log.Fatalln("No google civic API key found")
 	}
 
 	atClient := NewAirtableClient(AirtableConfig{
@@ -47,14 +52,13 @@ func main() {
 		APIKey: airtableKey,
 	})
 
-	var gErr error
-	globalIssues, gErr = NewIssueCache(atClient, 30*time.Minute)
-	if gErr != nil {
-		log.Fatalln(gErr)
+	issueLister, err := NewIssueCache(atClient, 30*time.Minute)
+	if err != nil {
+		log.Fatalln(err)
 	}
 
 	cAPI := NewCivicAPI(civicKey, http.DefaultClient)
-	repFinder = NewRepCache(cAPI, time.Hour, 10*time.Minute)
+	repFinder := NewRepCache(cAPI, time.Hour, 10*time.Minute)
 
 	// index template... unused
 	p, err := template.ParseFiles("index.html")
@@ -64,80 +68,37 @@ func main() {
 	pagetemplate = p
 
 	// open database
-	db, err = sql.Open("sqlite3", fmt.Sprintf("./%s", *dbfile))
+	file := fmt.Sprintf("./%s", *dbfile)
+	db, err := sql.Open("sqlite3", file)
 	if err != nil {
-		log.Printf("can't open databse: %s", err)
-		return
+		log.Fatalln("can't open database,", file, err)
 	}
 	defer db.Close()
 
+	h := &handler{
+		repFinder:   repFinder,
+		issueLister: issueLister,
+	}
+	a := &adminHandler{
+		reloader: issueLister.(cacheReloader),
+	}
+	rh := &reportHandler{db: db}
 	// set up http routing
 	r := mux.NewRouter()
-	r.HandleFunc("/issues/{zip}", pageHandler)
-	r.HandleFunc("/issues/", pageHandler)
-	r.HandleFunc("/admin/", adminHandler)
-	r.HandleFunc("/admin/refresh", adminRefreshHandler)
-	r.HandleFunc("/report/", reportHandler)
-	http.Handle("/", r)
+
+	// all the GETs
+	get := r.Methods("GET").Subrouter()
+	get.HandleFunc("/issues/{zip}", enableCORS(h.GetIssues))
+	get.HandleFunc("/issues/", enableCORS(h.GetIssues))
+	get.HandleFunc("/admin/", a.Stats)
+	get.HandleFunc("/report/", enableCORS(rh.Stats))
+	get.HandleFunc("/report", enableCORS(rh.Stats))
+
+	// all the POSTs
+	post := r.Methods("POST").Subrouter()
+	post.HandleFunc("/admin/refresh", a.ReloadCache)
+	post.HandleFunc("/report", enableCORS(rh.RegisterCall))
+
 	log.Printf("running fivecalls-web on port %v", *addr)
-
-	log.Fatal(http.ListenAndServe(*addr, nil))
-}
-
-func pageHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
-		http.Error(w, "GET only", 403)
-		return
-	}
-
-	vars := mux.Vars(r)
-	zip := vars["zip"]
-
-	var localReps *LocalReps
-	var err error
-
-	if len(zip) == 5 && zip != "" {
-		log.Printf("zip %s", zip)
-		localReps, _, err = repFinder.GetReps(zip)
-		if err != nil {
-			log.Println("Unable to find local reps for", zip, err)
-		}
-	} else {
-		log.Printf("no zip")
-	}
-
-	// add local reps where necessary
-	customizedIssues := []Issue{}
-	all, err := globalIssues.AllIssues()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	for _, issue := range all {
-		newContacts := []Contact{}
-		for _, contact := range issue.Contacts {
-			if contact.Name == "LOCAL REP" {
-				if localReps != nil {
-					if localReps.HouseRep != nil {
-						c := *localReps.HouseRep
-						c.Reason = "This is your local representative in the house"
-						newContacts = append(newContacts, c)
-					}
-					for _, s := range localReps.Senators {
-						c := *s
-						c.Reason = "This is one of your two senators"
-						newContacts = append(newContacts, c)
-					}
-				}
-			} else {
-				newContacts = append(newContacts, contact)
-			}
-		}
-		issue.Contacts = newContacts
-		customizedIssues = append(customizedIssues, issue)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	json.NewEncoder(w).Encode(customizedIssues)
+	log.Fatal(http.ListenAndServe(*addr, r))
 }

--- a/go/models.go
+++ b/go/models.go
@@ -25,3 +25,19 @@ type Contact struct {
 func (c *Contact) String() string {
 	return asJson(c)
 }
+
+// LocalReps are the contacts that constitute local representatives
+// for a supplied address.
+type LocalReps struct {
+	HouseRep *Contact   // house representative
+	Senators []*Contact // senators
+}
+
+// Address is a US address. It has the same structure as the normalized
+// address returned by the civic API.
+type Address struct {
+	Line1 string
+	City  string
+	State string
+	Zip   string
+}

--- a/go/models.go
+++ b/go/models.go
@@ -4,9 +4,13 @@ package main
 type Issue struct {
 	ID       string    `json:"id"`
 	Name     string    `json:"name"`
-	Reason	 string    `json:"reason"`
+	Reason   string    `json:"reason"`
 	Script   string    `json:"script"`
 	Contacts []Contact `json:"contacts"`
+}
+
+func (i *Issue) String() string {
+	return asJson(i)
 }
 
 // Contact is a single point of contact related to an issue
@@ -16,4 +20,8 @@ type Contact struct {
 	PhotoURL string `json:"photoURL"`
 	Reason   string `json:"reason"`
 	Area     string `json:"area"`
+}
+
+func (c *Contact) String() string {
+	return asJson(c)
 }

--- a/go/report.go
+++ b/go/report.go
@@ -1,81 +1,50 @@
 package main
 
 import (
-	"encoding/json"
-	// "log"
+	"database/sql"
+	"fmt"
 	"net/http"
-	"strconv"
 	"time"
-
-	"github.com/patrickmn/go-cache"
 )
 
-func reportHandler(w http.ResponseWriter, r *http.Request) {
-	var returnData = map[string]string{}
+type reportHandler struct {
+	db *sql.DB
+}
 
-	if r.Method == "GET" {
-		var count int
+func (h *reportHandler) Stats(w http.ResponseWriter, r *http.Request) {
+	var count int
+	row := h.db.QueryRow("SELECT count(*) FROM results")
+	if err := row.Scan(&count); err != nil {
+		http.Error(w, "can't get results", 500)
+		return
+	}
+	writeJSON(w, map[string]string{"count": fmt.Sprint(count)})
+}
 
-		if cacheInt, countFound := countCache.Get("totalCount"); countFound {
-			count = cacheInt.(int)
-		} else {
-			rows, err := db.Query("SELECT count(*) FROM results")
-			if err != nil {
-				http.Error(w, "can't get number of results", 500)
-				return
-			}
-
-			for rows.Next() {
-				err = rows.Scan(&count)
-				if err != nil {
-					http.Error(w, "can't get results", 500)
-					return
-				}
-			}
-			rows.Close()
-
-			countCache.Set("totalCount", count, cache.DefaultExpiration)
-		}
-
-		returnData["count"] = strconv.Itoa(count)
-	} else if r.Method == "POST" {
-		r.ParseForm()
-		location := r.FormValue("location")
-		if location == "" {
-			location = "NONE"
-		}
-		result := r.FormValue("result")
-		if result == "" {
-			http.Error(w, "must pass result", 400)
-			return
-		}
-
-		stmt, err := db.Prepare("INSERT INTO results(location, result, time) values(?,?,?)")
-		if err != nil {
-			http.Error(w, "can't prepare statement", 500)
-			return
-		}
-
-		now := time.Now()
-		_, err = stmt.Exec(location, result, now.Unix())
-		if err != nil {
-			http.Error(w, "can't exec statement", 500)
-			return
-		}
-
-		returnData["ok"] = "true"
-	} else {
-		http.Error(w, "GET or POST only", 403)
+func (h *reportHandler) RegisterCall(w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+	location := r.FormValue("location")
+	if location == "" {
+		location = "NONE"
+	}
+	result := r.FormValue("result")
+	if result == "" {
+		http.Error(w, "must pass result", 400)
 		return
 	}
 
-	jsonData, err := json.Marshal(returnData)
+	stmt, err := h.db.Prepare("INSERT INTO results(location, result, time) values(?,?,?)")
 	if err != nil {
-		http.Error(w, err.Error(), 500)
+		http.Error(w, "can't prepare statement", 500)
 		return
 	}
+	defer stmt.Close()
 
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Write(jsonData)
+	now := time.Now()
+	_, err = stmt.Exec(location, result, now.Unix())
+	if err != nil {
+		http.Error(w, "can't exec statement", 500)
+		return
+	}
+	writeJSON(w, map[string]bool{"ok": true})
 }


### PR DESCRIPTION
As described in the commits:

#### commit 1: Refactor airtable data access and implement refresh

* use the airtable-go MIT licensed library. This handles full CRUD as well
  as pagination for lists.
* Make the Contact and Issue objects the return value for getting all issues
* Wrap the airtable client with an in-memory cache that automatically refreshes
  from Db every so often.
* Make the minimum changes to the handlers for the refactored interface

#### commit 2 : Refactor civics API and use a new model object as return value

* Simplify civics API implementation to filter by role rather than level
* Create a new LocalReps model object and have the civics API return it
* API now also returns the normalized address as returned by Google
* Create a cache wrapper to decouple cache logic from webservice logic

#### commit 3 : Refactor handlers, lose global variables

* Extract handler functions into struct methods
* Handlers use interfaces to get their job done
* Routing simplified to mount GET and POST routes separately
* CORS handling moved to main
