### PR TITLE
Refine mobile view

### DIFF
--- a/static/js/components/done.js
+++ b/static/js/components/done.js
@@ -9,7 +9,7 @@ module.exports = (state, prev, send) => {
         <p class="call__complete__text">Calling your representatives is the most effective way of making your voice heard. <a href="#about">Read more</a> about why calling your representatives is important to our democracy.</p>
         <p class="call__complete__text">Pick another issue to continue. Or spread the word by sharing your accomplishment with your friends:</p>
         <p class="call__complete__share"><a target="_blank" href="https://twitter.com/intent/tweet?text=Make%205%20calls%20today%20to%20change%20your%20government%20http%3A%2F%2Fbit.ly%2F2iJb5nH&source=webclient&via=make5calls"><i class="fa fa-twitter" aria-hidden="true"></i> Share on Twitter</a> - <a  target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=http://bit.ly/2iJb5nH"><i class="fa fa-facebook" aria-hidden="true"></i> Share on Facebook</a></p>
-        <p class="call__complete__text">Together we've made ${state.totalCalls.toLocaleString()} calls to government offices and officials.</p>
+        <p class="call__complete__text">Together we've made ${state.totalCalls.toLocaleString().replace(/\D\d\d$/, '')} calls to government offices and officials.</p>
       </div>
     </section>
     </main>

--- a/static/js/components/hypothesis.js
+++ b/static/js/components/hypothesis.js
@@ -15,7 +15,7 @@ module.exports = (state, prev, send) => {
         <p>Want to know more? Read about <a href="#about">why calling works</a> or <a href="#about">more about us</a></p>
       </div>
       <p class="hypothesis__stats">
-        ${state.totalCalls.toLocaleString()} calls to date
+        ${state.totalCalls.toLocaleString().replace(/\D\d\d$/, '')} calls to date
       </p>
     </div>
   `;

--- a/static/scss/_call.scss
+++ b/static/scss/_call.scss
@@ -2,17 +2,32 @@
   background-color: fade-out(#fff, 0.3);
   padding: 2rem;
 
+  @include bp(small) {
+    padding: 1rem .5rem;
+  }
+
   &__title {
   	margin: 0;
   	font-size: 3.4rem;
   	text-transform: uppercase;
-  	xtext-align: center;
+  	text-align: left;
+    line-height: 1.1;
+
+    @include bp(small) {
+      font-size: 2.2rem;
+    }
+
   }
 
   &__reason {
   	font-size: 1.4rem;
   	font-weight: 300;
-  	line-height: 2rem;
+  	line-height: 1.4;
+
+    @include bp(small) {
+      font-size: 1.2rem;
+    }
+
   }
 
   &__contact {
@@ -21,6 +36,11 @@
       width: 200px;
       height: 200px;
       margin: 0 1rem 1rem 0;
+
+      @include bp(small) {
+        float: none;
+        margin: 0 auto;
+      }
 
       img {
         max-width: 100%;
@@ -38,21 +58,39 @@
       margin-bottom: 0.1rem;
       font-size: 2.8rem;
       font-weight: 600;
+
+      @include bp(small) {
+        font-size: 2.2rem;
+      }
+
     }
 
     &__phone {
       margin-bottom: 0.1rem;
       font-size: 5rem;
       font-weight: 600;
+
+      @include bp(small) {
+        font-size: 2rem;
+        font-size: 14vw;
+        margin: .5rem 0;
+      }
+
+
     }
 
     &__reason {
       font-size: 1.4rem;
-      line-height: 1.8rem;
+      line-height: 1.4;
 
       @media only screen and (min-width: $bp-large) {
         margin-left: calc(200px + 1rem);
       }
+
+      @include bp(small) {
+        font-size: 1.2rem;
+      }
+
     }
   }
 
@@ -69,7 +107,12 @@
       background-color: fade-out(#fff, 0.5);
       font-size: 1.4rem;
       font-weight: 300;
-      line-height: 2rem;
+      line-height: 1.4;
+
+      @include bp(small) {
+        font-size: 1.2rem;
+      }
+
     }
   }
 
@@ -109,8 +152,9 @@
 
   &__promote {
     p {
-      margin: 0;
+      padding: 1rem 0;
       text-align: center;
+      line-height: 1.5;
     }
   }
 
@@ -127,7 +171,8 @@
       margin: 2rem 0 2rem 0;
       font-size: 1.5rem;
       font-weight: 300;
-      line-height: 2rem;
+      line-height: 1.4;
+
     }
 
     &__share {

--- a/static/scss/_variables-and-mixins.scss
+++ b/static/scss/_variables-and-mixins.scss
@@ -17,3 +17,15 @@ $font-sans: 'Roboto Condensed', sans-serif;
 $bp-large:  85rem;
 $bp-medium: 45rem;
 $bp-small:  28rem;
+// for debugging layout
+@mixin debug-layout($color: black, $important: false) {
+  @if $important {
+    * {
+      background: rgba($color, .05) !important;
+    }
+  } @else {
+    * {
+      background: rgba($color, .05);
+    }
+  }
+}

--- a/static/scss/_variables-and-mixins.scss
+++ b/static/scss/_variables-and-mixins.scss
@@ -17,6 +17,22 @@ $font-sans: 'Roboto Condensed', sans-serif;
 $bp-large:  85rem;
 $bp-medium: 45rem;
 $bp-small:  28rem;
+
+// mixin to reduce amount of code for responsive design tweaks
+@mixin bp($point) {
+
+  @if $point == large {
+    @media only screen and (min-width: $bp-large) { @content; }
+  }
+  @else if $point == medium {
+    @media only screen and (max-width: $bp-medium) { @content; }
+  }
+  @else if $point == small {
+    @media only screen and (max-width: $bp-small) { @content; }
+  }
+
+}
+
 // for debugging layout
 @mixin debug-layout($color: black, $important: false) {
   @if $important {

--- a/static/scss/_variables-and-mixins.scss
+++ b/static/scss/_variables-and-mixins.scss
@@ -16,4 +16,4 @@ $font-sans: 'Roboto Condensed', sans-serif;
 
 $bp-large:  85rem;
 $bp-medium: 45rem;
-$bp-small:  20rem;
+$bp-small:  28rem;

--- a/static/scss/style.scss
+++ b/static/scss/style.scss
@@ -11,3 +11,6 @@
 @import 'hypothesis';
 @import 'call';
 @import 'about';
+
+// enable to debug layout
+// @include debug-layout();


### PR DESCRIPTION
Thanks for building this @nickoneill! 

I've refined the mobile layout with better font sizes on the call page. I've also added a mixin that let's you specify the breakpoint with less code.

The phone size doesn't fill column width, but it's much better than where we started.

Here are some after/before examples:

![5calls-example0](https://cloud.githubusercontent.com/assets/1584916/22349849/179ba8c4-e3d7-11e6-9436-e5d65ae0c800.png)
![5calls-example1](https://cloud.githubusercontent.com/assets/1584916/22349850/179f3be2-e3d7-11e6-88b8-c8fcc41c93b0.png)
