### PR TITLE
Display block removes extra space caused by clever tricks to hide text.

### DIFF
--- a/static/scss/_issues.scss
+++ b/static/scss/_issues.scss
@@ -18,6 +18,7 @@
     text-transform: uppercase;
 
     a {
+      display: block;
       color: inherit;
       text-decoration: none;
       font-size: 0.1px;


### PR DESCRIPTION
## Before

![image](https://cloud.githubusercontent.com/assets/28444/22362493/d8d36244-e417-11e6-8a8a-acfc2e5c6dd8.png)

## After

![image](https://cloud.githubusercontent.com/assets/28444/22362506/f4f814c4-e417-11e6-8697-3d1e19efb1db.png)
