### PR TITLE
Add governor type contact

### DIFF
--- a/go/civic.go
+++ b/go/civic.go
@@ -95,21 +95,25 @@ func (r *apiResponse) toLocalReps() (*LocalReps, *Address, error) {
 	ret := &LocalReps{}
 	for _, o := range r.Offices {
 		var area string
-		for _, level := range o.Levels {
-			for _, role := range o.Roles {
-				switch {
-				case level == roleLevelCountry && role == roleLowerBody:
-					area = areaHouse
-				case level == roleLevelCountry && role == roleUpperBody:
-					area = areaSenate
-				// Civic API returns governor and deputy governor under same
-				// role level and role, comparing the name is the best we can do
-				// with this dataset
-				case level == roleLevelState && role == roleHeadOfGovernment && o.Name == "Governor":
-					area = areaGovernor
+		AreaLoop:
+			for _, level := range o.Levels {
+				for _, role := range o.Roles {
+					switch {
+					case level == roleLevelCountry && role == roleLowerBody:
+						area = areaHouse
+						continue AreaLoop
+					case level == roleLevelCountry && role == roleUpperBody:
+						area = areaSenate
+						continue AreaLoop
+					// Civic API returns governor and deputy governor under same
+					// role level and role, comparing the name is the best we can do
+					// with this dataset
+					case level == roleLevelState && role == roleHeadOfGovernment && o.Name == "Governor":
+						area = areaGovernor
+						continue AreaLoop
+					}
 				}
 			}
-		}
 		if area != "" {
 			for _, i := range o.OfficialIndices {
 				official := r.Officials[i]

--- a/go/handler.go
+++ b/go/handler.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	localPlaceholder  = "LOCAL REP"
-	senatePlaceholder = "US SENATE"
-	housePlaceholder  = "US HOUSE"
+	localPlaceholder    = "LOCAL REP"
+	senatePlaceholder   = "US SENATE"
+	housePlaceholder    = "US HOUSE"
+	governorPlaceholder = "GOVERNOR"
 )
 
 type handler struct {
@@ -84,6 +85,14 @@ func (h *handler) GetIssues(w http.ResponseWriter, r *http.Request) {
 					if localReps.HouseRep != nil {
 						c := *localReps.HouseRep
 						c.Reason = "This is your local representative in the house"
+						newContacts = append(newContacts, c)
+					}
+				}
+			} else if contact.Name == governorPlaceholder {
+				if localReps != nil {
+					if localReps.Governor != nil {
+						c := *localReps.Governor
+						c.Reason = "This is your state governor"
 						newContacts = append(newContacts, c)
 					}
 				}

--- a/go/models.go
+++ b/go/models.go
@@ -39,6 +39,7 @@ func (c *Contact) String() string {
 type LocalReps struct {
 	HouseRep *Contact   // house representative
 	Senators []*Contact // senators
+	Governor *Contact   // governor
 }
 
 // Address is a US address. It has the same structure as the normalized


### PR DESCRIPTION
This adds a governor type contact to the contact list returned by issues API. If
contact name == `GOVERNOR`, this lookup will take place.

And, uh, pardon my Go etiquette, this is all new to me.

Fixes #28 