### PR TITLE
Scroll to address input

### DIFF
--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -4,12 +4,13 @@ module.exports = (state, prev, send) => {
   return html`
     <div class="issues__location">
     ${pretext(state)}
+    ${addressForm(state)}
     </div>
   `;
 
   function pretext(state) {
     if (state.askingLocation) {
-      return html`<p><form onsubmit=${submitAddress}><input type="text" autofocus="true" name="address" placeholder="Enter an address or zip code" /> <button>Go</button></form></p>`
+      return html``;
     } else {
       if (state.address != '') {
         return html`<p>for <a href="#" onclick=${enterLocation}>${state.address}</a></p>`
@@ -19,6 +20,11 @@ module.exports = (state, prev, send) => {
         return html`<p><a href="#" onclick=${enterLocation}>Choose a location</a></p>`
       }
     }
+  }
+
+  function addressForm(state) {
+    const className = state.askingLocation ? '' : 'hidden';
+    return html`<p><form onsubmit=${submitAddress} class=${className}><input type="text" autofocus="true" id="address" name="address" placeholder="Enter an address or zip code" /> <button>Go</button></form></p>`
   }
 
   function debugText(debug) {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -129,6 +129,7 @@ app.model({
       return { geolocation: data }
     },
     enterLocation: (state, data) => {
+      scrollIntoView(document.querySelector('#address'));
       return { askingLocation: true }
     },
     resetLocation: (state, data) => {


### PR DESCRIPTION
On mobile browsers, tapping "set your location" at the bottom of the page has no visible effect since the address field is scrolled offscreen. This diff scrolls the address input into view when "set your location" is tapped. This requires the form element to be in the DOM, so it is hidden when the user doesn't need to see it. Verified this behavior in desktop Chrome as well, though scrolling is only necessary on small screens.

![iOS simulator screenshot](https://cloud.githubusercontent.com/assets/3497/22454576/af33290c-e73b-11e6-823b-88867d80caf4.png)
