### PR TITLE
Fixed Readme link to Google Civic Information API page

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Airtable database.
 
 ##### Get a Google Civic API Key
 
-Follow the instructions [here](civic-api) to get an API key for the Google Civic API.
+Follow the instructions [here](https://developers.google.com/civic-information/docs/using_api) to get an API key for the Google Civic Information API.
 
 ##### Point to Local Back End
 


### PR DESCRIPTION
The link to the Google Civic Information API in the Readme file pointed to a non-existent Github page. This PR fixes that issue.