### PR TITLE
Initial mocha config and callcount component JavaScript unit test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ var gulp = require('gulp')
   , uglify = require('gulp-uglify')
   , http_server = require('http-server')
   , connect_logger = require('connect-logger')
+  , mocha = require('gulp-mocha');
   ;
 
 var SRC = {
@@ -109,6 +110,13 @@ gulp.task('scripts:watch', function() {
 gulp.task('extra', function() {
   gulp.src(SRC.extra + '/*.+(ico|xml|json)')
     .pipe(gulp.dest(DEST.html));
+});
+
+gulp.task('test', function() {
+  return gulp.src(['**/*_test.js', '!./node_modules/**'], { read: false })
+    .pipe(mocha({
+      reporter: 'spec',
+    }));
 });
 
 gulp.task('default', ['html', 'html:watch', 'html:serve', 'sass', 'sass:watch', 'copy-images', 'copy-images:watch', 'scripts', 'scripts:watch', 'extra']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "gulpfile.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "gulp test"
   },
   "repository": {
     "type": "git",
@@ -14,12 +14,16 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "browserify": "^13.1.1",
+    "chai": "^3.5.0",
     "es2040": "^1.2.4",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-imagemin": "^3.1.1",
+    "gulp-mocha": "^3.0.1",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.1",
+    "mocha": "^3.2.0",
+    "sinon": "^1.17.7",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
   },

--- a/static/js/components/callcount_test.js
+++ b/static/js/components/callcount_test.js
@@ -1,0 +1,32 @@
+const html = require('choo/html');
+const callcount = require('./callcount.js');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('callcount component', () => {
+  it('should properly forma call total >=1000 with commas', () => {
+    let state = {totalCalls: '123456789'};
+    let result = callcount(state);
+    expect(result.childNodes[1].data).to.contain('123,456,789');
+  });
+
+  it('should properly format call total < 1000 without commas', () => {
+    const totals = '123';
+    let state = {totalCalls: totals};
+    let result = callcount(state);
+    // console.log('Result: ', result.childNodes);
+    expect(result.childNodes[1].data).to.contain(totals);
+    expect(result.childNodes[1].data).to.not.contain(',');
+  });
+
+  it('should not format zero call total', () => {
+    const totals = '0';
+    let state = {totalCalls: totals};
+    let result = callcount(state);
+    // console.log('Result: ', result.childNodes);
+    // expect(result.childNodes[1].data).to.contain('123');
+    expect(result.childNodes[1].data).to.contain(totals);
+    expect(result.childNodes[1].data).to.not.contain(',');
+  });
+
+});


### PR DESCRIPTION
This is the initial JavaScript testing configurations and a unit test (callcount_test.js) as described in issue #96 . The tests can be run using ```gulp test``` or ```npm test```