### PR TITLE
Informs the user they've entered an invalid address/zip

### DIFF
--- a/go/handler.go
+++ b/go/handler.go
@@ -8,6 +8,8 @@ import (
 )
 
 const (
+	addrFailedToParse = "400 Failed to parse address"
+	addrNoInfo        = "404 No information for this address"
 	localPlaceholder  = "LOCAL REP"
 	senatePlaceholder = "US SENATE"
 	housePlaceholder  = "US HOUSE"
@@ -41,7 +43,8 @@ func (h *handler) GetIssues(w http.ResponseWriter, r *http.Request) {
 		localReps, normalizedAddress, err = h.repFinder.GetReps(civicLocationParam)
 		if err != nil {
 			log.Println("Unable to find local reps for", zip, err)
-			if err.Error() == "400 Failed to parse address" {
+			invalidAddress := err.Error() == addrFailedToParse || err.Error() == addrNoInfo
+			if invalidAddress {
 				issueResponse.InvalidAddress = true
 			}
 		}

--- a/go/handler.go
+++ b/go/handler.go
@@ -34,18 +34,21 @@ func (h *handler) GetIssues(w http.ResponseWriter, r *http.Request) {
 		civicLocationParam = address
 	}
 
+	issueResponse := IssueResponse{}
 	if len(civicLocationParam) != 0 {
 		log.Println("getting local reps for", civicLocationParam)
 
 		localReps, normalizedAddress, err = h.repFinder.GetReps(civicLocationParam)
 		if err != nil {
 			log.Println("Unable to find local reps for", zip, err)
+			if err.Error() == "400 Failed to parse address" {
+				issueResponse.InvalidAddress = true
+			}
 		}
 	} else {
 		log.Println("no address or zip")
 	}
 
-	issueResponse := IssueResponse{}
 	if localReps != nil && localReps.HouseRep == nil {
 		issueResponse.SplitDistrict = true
 	}

--- a/go/models.go
+++ b/go/models.go
@@ -2,6 +2,7 @@ package main
 
 type IssueResponse struct {
 	SplitDistrict      bool    `json:"splitDistrict"`
+	InvalidAddress     bool    `json:"invalidAddress"`
 	NormalizedLocation string  `json:"normalizedLocation"`
 	Issues             []Issue `json:"issues"`
 }

--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -42,6 +42,10 @@ module.exports = (state, prev, send) => {
 
   function enterLocation(e) {
     e.preventDefault();
+    // Clear previously invalid address to reinforce entering a new one
+    if (state.invalidAddress) {
+      document.getElementById("address").value = "";
+    }
     send('enterLocation');
   }
 

--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -12,7 +12,9 @@ module.exports = (state, prev, send) => {
     if (state.askingLocation) {
       return html``;
     } else {
-      if (state.address != '') {
+      if (state.invalidAddress) {
+        return html`<p><a href="#" onclick=${enterLocation}>That address is invalid, please try again</a></p>`
+      } else if (state.address != '') {
         return html`<p>for <a href="#" onclick=${enterLocation}>${state.address}</a></p>`
       } else if (state.cachedCity != '') {
         return html`<p>for <a href="#" onclick=${enterLocation}> ${state.cachedCity}</a> ${debugText(state.debug)}</p>`

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -81,7 +81,7 @@ app.model({
     receiveIssues: (state, data) => {
       response = JSON.parse(data)
       issues = response.issues //.filter((v) => { return v.contacts.length > 0 });
-      return { issues: issues, splitDistrict: response.splitDistrict }
+      return { issues: issues, splitDistrict: response.splitDistrict, invalidAddress: response.invalidAddress }
     },
     receiveTotals: (state, data) => {
       totals = JSON.parse(data);


### PR DESCRIPTION
The Civic API returns `400` [responses](https://developers.google.com/civic-information/docs/v2/standard_errors) for many reasons. Of those is a `parseError` where they return "Failed to parse address" for invalid addresses.

In the event that the user enters a zip or address that the Civic API was unable to parse, we present that information to the user and ask them to try again.

This should resolve #88 