### PR TITLE
Suppress quota exceptions in localStorage

### DIFF
--- a/static/js/utils/localstorage.js
+++ b/static/js/utils/localstorage.js
@@ -10,21 +10,30 @@ module.exports = {
   add: (storeName, item, cb) => {
     module.exports.getAll(storeName, (items) => {
       items.push(item)
-      window.localStorage[storeName] = JSON.stringify(items)
-      cb()
+      saveStore(storeName, JSON.stringify(items), cb)
     })
   },
   replace: (storeName, index, item, cb) => {
     module.exports.getAll(storeName, (items) => {
       items[index] = item
-      window.localStorage[storeName] = JSON.stringify(items)
-      cb()
+      saveStore(storeName, JSON.stringify(items), cb)
     })
   },
   remove: (storeName, cb) => {
     module.exports.getAll(storeName, (items) => {
-      window.localStorage[storeName] = null
+      window.localStorage.removeItem(storeName)
       cb()
     })
   },
+}
+
+// handle storage quota errors
+function saveStore (storeName, storeItems, cb) {
+  try {
+    window.localStorage[storeName] = storeItems
+    cb()
+  }
+  catch (e) {
+    cb(e)
+  }
 }


### PR DESCRIPTION
This fixes #126 by suppressing any exceptions when setting items in `localStorage`. (In private browsing mode, Safari sets the storage quota to 0, which means localStorage throws an exception whenever you try to set anything.)

I started to write tests as well, but realized that required changing the test process significantly: it needs to run in a browser or needs a tool like [`mocha-jsdom`](https://www.npmjs.com/package/mocha-jsdom) or [`jsdom-global`](http://npmjs.com/package/jsdom-global), though the latter seems to conflict with other tests. I’m happy to do that work, too, if you want it.