### PR TITLE
Dynamic call scripts part 1 - fill in representative info

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "choo": "^4.1.0",
     "connect-logger": "0.0.1",
+    "gender-detection": "0.0.5",
     "gulp-util": "^3.0.8",
     "http-server": "^0.9.0",
     "lodash": "^4.17.2",

--- a/static/js/components/call.js
+++ b/static/js/components/call.js
@@ -42,7 +42,7 @@ module.exports = (state, prev, send) => {
 
     ${contactArea()}
 
-    ${script(state, prev, send)}
+    ${script(currentContact, state, prev, send)}
 
     ${outcomes(state, prev, send)}
 

--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -1,16 +1,31 @@
 const html = require('choo/html');
 const find = require('lodash/find');
+const gender = require('gender-detection');
 const scriptLine = require('./scriptLine.js');
 
 module.exports = (contact, state, prev, send) => {
 	  const issue = find(state.issues, ['id', state.location.params.issueid]);
 	  const currentContact = issue.contacts[state.contactIndex];
 
+    const repGender = gender.detect(contact.name);
+    const titleMap = { male: 'Mr. ', female: 'Ms. ', unisex: '' };
+    const pronounMap = { male: 'him', female: 'her', unisex: 'them' };
+    const repTitle = titleMap[repGender];
+    const formalName = `${repTitle}${contact.name.split(' ').pop()}`;
+
+    const scriptFormatter = (issue) =>
+      issue.script.replace('[him/her]', pronounMap[repGender])
+                  .replace('[Senator/Rep’s Name]', formalName)
+                  .replace('[Senator/Rep\'s Name]', formalName)
+                  .replace('[Senator’s Name]', formalName)
+                  .replace('[Senator\'s Name]', formalName)
+                  .split('\n').map((line) => scriptLine(line, state, prev, send));
+
     if (currentContact != null) {
       return html`
       <div class="call__script">
         <h3 class="call__script__header">Your script:</h3>
-        <div class="call__script__body">${issue.script.split('\n').map((line) => scriptLine(line, state, prev, send))}</div>
+        <div class="call__script__body">${scriptFormatter(issue)}</div>
       </div>`
     } else {
       return html``

--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -2,16 +2,16 @@ const html = require('choo/html');
 const find = require('lodash/find');
 const scriptLine = require('./scriptLine.js');
 
-module.exports = (state, prev, send) => {
+module.exports = (contact, state, prev, send) => {
 	  const issue = find(state.issues, ['id', state.location.params.issueid]);
 	  const currentContact = issue.contacts[state.contactIndex];
-    
+
     if (currentContact != null) {
       return html`
       <div class="call__script">
         <h3 class="call__script__header">Your script:</h3>
         <div class="call__script__body">${issue.script.split('\n').map((line) => scriptLine(line, state, prev, send))}</div>
-      </div>`      
+      </div>`
     } else {
       return html``
     }


### PR DESCRIPTION
This is in response to #85, though it may not cover all of the desired behavior.

*Summary:*

- Add dependency on `gender-detection` package (see discussion below)
- Change signature of `script` component to take `currentContact`
- Add templating to script component to fill in the user's current contact's information

*Example:*

Prior behavior:

> Hi, my name is [Name] and I'm a constituent from [City, State, Zip].
>
>I’m calling to tell [Senator/Rep’s Name] that our community does not support Trump’s Muslim ban, and we expect [him/her] to take an immediate stand against this unjust executive order.
>
>[Optional: add anything else you’d like here]
>
>Thank you for your time.

With this change:


> Hi, my name is [Name] and I'm a constituent from [City, State, Zip].
>
>I’m calling to tell Ms. Feinstein that our community does not support Trump’s Muslim ban, and we expect her to take an immediate stand against this unjust executive order.
>
>[Optional: add anything else you’d like here]
>
>Thank you for your time.

*Discussion:*

I was really reluctant to infer gender. I have seen some fights in other open-source projects about this exact issue. However, without doing so, the filled-in scripts just felt awkward. I feel like the point of this modification is to make the process even _easier_ for people who are uncomfortable on the phone, and giving them an awkward-sounding script wouldn't accomplish that. Also, currently, all representatives are gender binary, so that's a factor too.

So, why this particular package for inferring gender? It doesn't use `fs`, so it can be browserified. There may be other options, I examined a few, and this one seemed ok.

*Todo:*

Still need to store the user's information in localStorage and fill that in as well.