### PR TITLE
Properly report number of remaining calls

### DIFF
--- a/static/js/components/outcomes.js
+++ b/static/js/components/outcomes.js
@@ -8,7 +8,7 @@ module.exports = (state, prev, send) => {
   const contactsLeft = issue.contacts.length - (state.contactIndex + 1);
   const callsPluralization = contactsLeft > 1 ? "people" : "person";
 
-  const contactsLeftText = contactsLeft > 0 ? contactsLeft + " more " + callsPluralization +" to call for this issue." : "You’ve made all the calls for this issue.";
+  const contactsLeftText = contactsLeft + " more " + callsPluralization +" to call for this issue.";
 
   function outcome(result) {
     if (result == null) {
@@ -28,7 +28,7 @@ module.exports = (state, prev, send) => {
         <button onclick=${() => outcome()}>Skip</button>
       </div>
 
-      <h3 class="call__contacts__left">${contactsLeftText}</h3>
+      ${contactsLeft > 0 ? html`<h3 class="call__contacts__left" >${contactsLeftText}</h3>` : null}
     </div>`
   } else {
     return html``


### PR DESCRIPTION
Addresses the first UI bug in task #78, but not the refresh-related issue.

The original string "You’ve made all the calls for this issue." doesn't ever appear correctly -- the "Great Work" section handles it nicely without the string, so I removed it.