### PR TITLE
Set debug mode based on localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ The other main Gulp task is the `deploy` task, which does not watch for
 changes, and applies additional transforms on the assets -- such as an uglify
 transform on Javascript sources.
 
+To turn on/off debug mode, which adds some reset buttons throughout the interface, run the following in your console:
+
+```
+localStorage['org.5calls.debug'] = 'true' // turn on debug mode
+localStorage['org.5calls.debug'] = 'false' // turn off debug mode
+```
+
 ### Application Server
 
 If you need to make any changes to the back end code, you'll need to set up
@@ -112,7 +119,7 @@ When updating the go server, remember to log in, connect to the screen instance 
  - [Beau Smith](https://github.com/beausmith)
  - [Anthony Johnson](https://github.com/agjohnson)
  - [All contriubtors](https://github.com/5calls/5calls/graphs/contributors)
- 
+
 ## Other client projects
  - [Android](https://github.com/5calls/android)
  - [iOS](https://github.com/5calls/ios)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -8,8 +8,10 @@ const scrollIntoView = require('scroll-into-view');
 
 const app = choo();
 const appURL = 'https://5calls.org';
-const debug = false;
 // const appURL = 'http://localhost:8090';
+
+// use localStorage directly to set this value *before* bootstrapping the app.
+const debug = (localStorage['org.5calls.debug'] === 'true');
 
 // get the stored zip location
 cachedAddress = '';

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -13,6 +13,10 @@ const appURL = 'https://5calls.org';
 // use localStorage directly to set this value *before* bootstrapping the app.
 const debug = (localStorage['org.5calls.debug'] === 'true');
 
+if (!debug) {
+  console.debug = () => {};
+}
+
 // get the stored zip location
 cachedAddress = '';
 store.getAll('org.5calls.location', (location) => {
@@ -25,7 +29,7 @@ store.getAll('org.5calls.location', (location) => {
 cachedGeo = '';
 store.getAll('org.5calls.geolocation', (geo) => {
   if (geo.length > 0) {
-    console.log("geo get",geo[0]);
+    console.debug("geo get", geo[0]);
     cachedGeo = geo[0]
   }
 });
@@ -36,7 +40,7 @@ let cachedFetchingLocation = (cachedGeo === '') ? true : false;
 cachedAllowBrowserGeo = true;
 store.getAll('org.5calls.allow_geolocation', (allowGeo) => {
   if (allowGeo.length > 0) {
-    console.log("allowGeo get",allowGeo[0]);
+    console.debug("allowGeo get", allowGeo[0]);
     cachedAllowBrowserGeo = allowGeo[0]
   }
 });
@@ -47,7 +51,7 @@ let cachedLocationFetchType = (cachedAllowBrowserGeo) ? 'browserGeolocation' : '
 cachedGeoTime = '';
 store.getAll('org.5calls.geolocation_time', (geo) => {
   if (geo.length > 0) {
-    console.log("geo time get",geo[0]);
+    console.debug("geo time get", geo[0]);
     cachedGeoTime = geo[0]
   }
 });
@@ -55,7 +59,7 @@ store.getAll('org.5calls.geolocation_time', (geo) => {
 cachedCity = '';
 store.getAll('org.5calls.geolocation_city', (city) => {
   if (city.length > 0) {
-    console.log("city get",city[0]);
+    console.debug("city get", city[0]);
     cachedCity = city[0]
   }
 });
@@ -192,7 +196,7 @@ app.model({
       }
 
       const issueURL = appURL+'/issues/'+address
-      // console.log("fetching url",issueURL);
+      // console.debug("fetching url",issueURL);
       http(issueURL, (err, res, body) => {
         send('setCachedCity', body, done)
         send('receiveIssues', body, done)


### PR DESCRIPTION
Addresses #157

To turn on debug mode, simply set the localStorage key to true in the console:
```
localStorage['org.5calls.debug'] = 'true'
```