### PR TITLE
Add startup action to about view to get issues

### DIFF
--- a/static/js/components/about.js
+++ b/static/js/components/about.js
@@ -2,7 +2,7 @@ const html = require('choo/html');
 
 module.exports = (state, prev, send) => {
   return html`
-    <main role="main" class="layout__main">
+    <main role="main" class="layout__main" onload=${(e) => send('startup')}>
     <section class="about">
       <h2 class="about__title">About 5 Calls</h2>
 


### PR DESCRIPTION
Fix issue #144 by adding the `startup` action to the about view. 

Next step should probably be to clean this up so that the action doesn't need to be individually called on several components. But for now: fixed!