### PR TITLE
.toLocaleString() expects a Number, not a string.

### DIFF
--- a/static/js/components/callcount.js
+++ b/static/js/components/callcount.js
@@ -3,7 +3,7 @@ const html = require('choo/html');
 module.exports = (state, prev, send) => {
   return html`
   <h2 class="callcount" onload=${(e) => send('getTotals')}>
-    Together we’ve made ${state.totalCalls.toLocaleString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")} calls
+    Together we’ve made ${Number(state.totalCalls).toLocaleString()} calls
   </h2>
   `;
 }


### PR DESCRIPTION
Same fix as previously merged fix in: https://github.com/5calls/5calls/pull/32. 

Looks like it got lost during the restyling. 😜  cc @jameshome 