### PR TITLE
BUGFIX: Only display link to field offices if contact has 'field_offices'

### DIFF
--- a/static/js/components/contact.js
+++ b/static/js/components/contact.js
@@ -11,7 +11,7 @@ module.exports = (c, state, prev, send) => {
   }
 
   let fieldOffices
-  if (!!~c.field_offices) {
+  if (c.field_offices) {
     fieldOffices = html`
       <p class="call__contact__show-field-offices">Busy line? <a onclick=${() => {send('toggleFieldOfficeNumbers')}}>Call a local office</a></p>
     `


### PR DESCRIPTION
The value returned from 'field_offices' is either null or an array.