### PR TITLE
Update to San Francisco number listed on www.harris.senate.gov

### DIFF
--- a/go/field_phones.go
+++ b/go/field_phones.go
@@ -86,7 +86,7 @@ var senateFieldOffices = map[string][]FieldOffice{
 		FieldOffice{Phone: "213-894-5000", City: "Los Angeles"},
 		FieldOffice{Phone: "916-448-2787", City: "Sacramento"},
 		FieldOffice{Phone: "619-239-3884", City: "San Diego"},
-		FieldOffice{Phone: "213-894-5000", City: "San Francisco"},
+		FieldOffice{Phone: "415-355-9041", City: "San Francisco"},
 	},
 	// Bennet, Michael (Colorado)
 	"2022245852": []FieldOffice{


### PR DESCRIPTION
This SF number was listed as the LA number.