### PR TITLE
Download, cache, and serve rep images

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -53,17 +53,18 @@ func main() {
 		log.Fatalln("No google civic API key found")
 	}
 
+	pc := new(photocache)
 	atClient := NewAirtableClient(AirtableConfig{
 		BaseID: *airtableBase,
 		APIKey: airtableKey,
-	})
+	}, pc)
 
 	issueLister, err := NewIssueCache(atClient, 30*time.Minute)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	cAPI := NewCivicAPI(civicKey, http.DefaultClient)
+	cAPI := NewCivicAPI(civicKey, http.DefaultClient, pc)
 	repFinder := NewRepCache(cAPI, time.Hour, 10*time.Minute)
 
 	// index template... unused
@@ -103,6 +104,7 @@ func main() {
 	get.HandleFunc("/admin/", a.Stats)
 	get.HandleFunc("/report/", enableCORS(rh.Stats))
 	get.HandleFunc("/report", enableCORS(rh.Stats))
+	get.HandleFunc("/photo/{key}", enableCORS(pc.serve))
 
 	// all the POSTs
 	post := r.Methods("POST").Subrouter()

--- a/go/photos.go
+++ b/go/photos.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"go4.org/syncutil/singleflight"
+)
+
+type photocache struct {
+	group singleflight.Group
+	// TODO: once https://go-review.googlesource.com/c/33912 goes in, use it here.
+	mu     sync.RWMutex      // guards following fields
+	photos map[string][]byte // key: key, val: cached photo
+}
+
+// get retrieves the photo keyed by key, downloading it from url if not cached.
+// if url is "", no download is attempted.
+func (c *photocache) get(key, url string) []byte {
+	c.mu.RLock()
+	if data, ok := c.photos[key]; ok {
+		c.mu.RUnlock()
+		return data
+	}
+	c.mu.RUnlock()
+	// Cache miss.
+	if url == "" {
+		// No idea where to fetch it, give up.
+		// Should not happen except during server restarts.
+		return nil
+	}
+	data, err := c.group.Do(key, func() (interface{}, error) {
+		log.Printf("photocache: fetch %s for %s", url, key)
+		resp, err := http.Get(url)
+		if err != nil {
+			return nil, err
+		}
+		data, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+		c.mu.Lock()
+		if c.photos == nil {
+			c.photos = make(map[string][]byte)
+		}
+		log.Printf("photocache: store %d bytes for %s", len(data), key)
+		c.photos[key] = data
+		c.mu.Unlock()
+		return data, nil
+	})
+	if err != nil {
+		log.Printf("photocache: fail to fetch %s for %s: %v", url, key, err)
+		return nil
+	}
+	return data.([]byte)
+}
+
+func (c *photocache) serve(w http.ResponseWriter, r *http.Request) {
+	key := mux.Vars(r)["key"]
+	// log.Printf("serve %q", key)
+	data := c.get(key, "")
+	if data == nil {
+		http.NotFound(w, r)
+		return
+	}
+	w.Write(data)
+}
+
+func (c *photocache) url(key string) string {
+	u := url.URL{Path: "/photo/" + key}
+	// log.Printf("url for %s: %s", key, u.String())
+	return u.String()
+}


### PR DESCRIPTION
It is late, so review skeptically. I will take another look at this tomorrow myself.

I'm not happy with how ugly it is to thread a reference to the photocache everywhere it needs threading. I'd be happy to substitute a global photocache instead.

In general, this should have minimal impact on response times, but the very first time we touch any given rep, it'll be slow. The waitgroup goo helps. It also slows down initial startup a little, but again, doing all the fetches in parallel helps.

See the commit message for further details.
