### PR TITLE
Use Choo to change url. Fixes #161

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -207,10 +207,6 @@ app.model({
         send('receiveTotals', body, done)
       })
     },
-    changeActiveIssueEffect: (state, issueId, send, done) => {
-      send('location:set', "/#issue/"+issueId, done)
-      send('changeActiveIssue', issueId, done)
-    },
     setLocation: (state, data, send, done) => {
       send('setAddress', data, done);
       send('fetch', {}, done);
@@ -340,9 +336,10 @@ app.model({
 
       scrollIntoView(document.querySelector('#content'));
 
-      // Use Choo's internal model to control Window.location.
-      send('location:set', "/#issue/" + data.id, done)
+      // Use Choo's internal model to control Window.location. Fixes issue #161
+      // For more information, see: https://github.com/yoshuawuyts/choo/blob/f84ec43fa58508cc20fe537d752a14901339f0cd/README.md#router
       // this strips the query string which breaks hashes, so temp workaround
+      send('location:set', "/#issue/" + data.id, done)
       // location = location.origin + "#issue/" + data.id;
       // location.hash = "issue/" + data.id;
     }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -340,8 +340,10 @@ app.model({
 
       scrollIntoView(document.querySelector('#content'));
 
+      // Use Choo's internal model to control Window.location.
+      send('location:set', "/#issue/" + data.id, done)
       // this strips the query string which breaks hashes, so temp workaround
-      location = location.origin + "#issue/" + data.id;
+      // location = location.origin + "#issue/" + data.id;
       // location.hash = "issue/" + data.id;
     }
   },


### PR DESCRIPTION
My brief reading of Choo documentation suggests we
should be using Choo's internal location model's reducer
when we want to change the url. Especially since we are
relying on it elsewhere to determine the params. See
https://github.com/yoshuawuyts/choo/blob/f84ec43fa58508cc20fe537d752a14901339f0cd/README.md#router
for more information.

With this change, selecting issues works for me
on IE 11 in Windows 7, fixing #161.