### PR TITLE
Different "No Contacts" message if split district (partial fix to #64)

### DIFF
--- a/static/js/components/noContact.js
+++ b/static/js/components/noContact.js
@@ -8,8 +8,7 @@ module.exports = (state, prev, send) => {
   }
 
   function noContactsMessage(state) {
-    if (state.splitDistrict == true && (state.address || state.cachedCity)) {
-    // if it's a split district but we have a location set
+    if (state.splitDistrict && (state.address || state.cachedCity)) {
       return html`<div>
                     <p>The location you provided could be in one of two congressional districts.</p>
                     <p><a onclick=${(e) => enterLocation(e)}>Enter your full address or Zip+4</a> to identify your representative in the House.</p>

--- a/static/js/components/noContact.js
+++ b/static/js/components/noContact.js
@@ -7,7 +7,21 @@ module.exports = (state, prev, send) => {
     send('enterLocation');
   }
 
-	return html`<div class="call__nocontact">
-		<h2><a onclick=${(e) => enterLocation(e)}>Set your location</a> to find your representatives</h2>
-	</div>`
+  function noContactsMessage(state) {
+    if (state.splitDistrict == true && (state.address || state.cachedCity)) {
+    // if it's a split district but we have a location set
+      return html`<div>
+                    <p>The location you provided could be in one of two congressional districts.</p>
+                    <p><a onclick=${(e) => enterLocation(e)}>Enter your full address or Zip+4</a> to identify your representative in the House.</p>
+                  </div>`
+    }
+    else {
+      return html`<h2><a onclick=${(e) => enterLocation(e)}>Set your location</a> to find your representatives</h2>`
+    }
+  }
+
+	return html`
+    <div class="call__nocontact">
+		  ${noContactsMessage(state)}
+	  </div>`
 }

--- a/static/scss/_call.scss
+++ b/static/scss/_call.scss
@@ -78,6 +78,13 @@
       font-size: $font-xxlarge;
       text-align: center;
     }
+    p {
+      font-size: $font-xlarge;
+      font-weight: bold;
+    }
+    a {
+       cursor: pointer;
+    }
   }
 
   &__script {


### PR DESCRIPTION
This is a partial fix for #64, which has come up on the slack a few times in the past week. 

Specifically, provides a more helpful message for the most general case in the issue, where we have location resolved as a split district but there are no contacts for a given issue. 

The fact that there's a split district isn't the only possible reason that no contacts could be returned for an issue when they've provided a valid location (see #171, etc), and entering a more specific location isn't necessarily going to fix it (in the case where it's just an address that the Civic API doesn't like), but it seems to be the most likely case AND the only one a user can take action on, so even in those cases it seems like a better message than the generic "set location" message.

It would be ideal to also provide messaging around this within issues, but the API doesn't return any information that would allow us to know that an issue _would have returned a house rep_ if it hadn't been a split district.

That would require some sort of API change to communicate _intended_ contacts (eg: only senators, only house reps, both) as well as the resolved ones, to know if we got what we were looking for (and message appropriately). Opening an issue around that shortly.