### PR TITLE
Run front-end tests in browsers via Karma

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,66 @@
+// Karma configuration
+// Generated on Tue Jul 26 2016 11:30:01 GMT-0700 (PDT)
+
+module.exports = function (config) {
+  config.set({
+     // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'browserify'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      'static/js/**/*_test.js'
+    ],
+
+    // list of files to exclude
+    exclude: [
+      'app/**/*'
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      '!(node_modules)/**/*.js': ['browserify'],
+    },
+
+    browserify: {
+      debug: true,
+      transform: ['es2040'],
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['mocha'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: [
+      'Chrome'
+    ],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -22,10 +22,15 @@
     "gulp-mocha": "^3.0.1",
     "gulp-sass": "^2.3.2",
     "gulp-uglify": "^2.0.1",
-    "mocha": "^3.2.0",
+    "karma": "^1.4.1",
+    "karma-browserify": "^5.1.1",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-mocha": "^1.3.0",
+    "karma-mocha-reporter": "^2.2.2",
     "sinon": "^1.17.7",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.9.0"
   },
   "dependencies": {
     "choo": "^4.1.0",

--- a/static/js/components/callcount_test.js
+++ b/static/js/components/callcount_test.js
@@ -7,7 +7,7 @@ describe('callcount component', () => {
   it('should properly forma call total >=1000 with commas', () => {
     let state = {totalCalls: '123456789'};
     let result = callcount(state);
-    expect(result.childNodes[1].data).to.contain('123,456,789');
+    expect(result.textContent).to.contain('123,456,789');
   });
 
   it('should properly format call total < 1000 without commas', () => {
@@ -15,8 +15,8 @@ describe('callcount component', () => {
     let state = {totalCalls: totals};
     let result = callcount(state);
     // console.log('Result: ', result.childNodes);
-    expect(result.childNodes[1].data).to.contain(totals);
-    expect(result.childNodes[1].data).to.not.contain(',');
+    expect(result.textContent).to.contain(totals);
+    expect(result.textContent).to.not.contain(',');
   });
 
   it('should not format zero call total', () => {
@@ -25,8 +25,8 @@ describe('callcount component', () => {
     let result = callcount(state);
     // console.log('Result: ', result.childNodes);
     // expect(result.childNodes[1].data).to.contain('123');
-    expect(result.childNodes[1].data).to.contain(totals);
-    expect(result.childNodes[1].data).to.not.contain(',');
+    expect(result.textContent).to.contain(totals);
+    expect(result.textContent).to.not.contain(',');
   });
 
 });


### PR DESCRIPTION
Addresses *part* of #131. Sorry this has taken me a week to get to. Have at it; let me know if this is any good.

I looked into a few different solutions (more below), but I think Karma with Mocha is going to be the best way forward here.

- It’s well used with lots of tools and plugins (easy to add browsers, coverage tools, SauceLabs/Browserstack, etc.)
- It handles sourcemaps and browserify great.
- Configuration is mostly straightforward and doesn’t add a lot of complexity to the codebase.

This sets us up with a simple config that runs tests in Chrome. It’s pretty easy to add other browsers, but I think we want to keep basic while-you’re-developing tests simple and fast (no reason for someone volunteering their help to get held up because they don’t have browser XYZ).

You can now also run `gulp test --watch` and have it watch JS files and re-run the tests whenever you make a change. (I noticed after writing this that there are `xxx:watch` tasks; should change this to match those? I like that it’s one implementation instead of two, but it’s inconsistent with everything else.)

There’s [another branch](https://github.com/Mr0grog/5calls/compare/tests-with-karma...Mr0grog:tests-with-karma-ci) where I was able to get tests across many browsers working nicely in Sauce Labs; that should be a next step when we add CI support.

---

### Side Notes

Some other experiments involved:

- [`jsdom-global`](https://github.com/5calls/5calls/compare/master...Mr0grog:localstorage-tests-with-jsdom-global) uses a JS implementation of the DOM to give us a browser-like environment in node. It’s fast and light, but not exceedingly accurate, since it’s not an actual browser engine. This last part makes me not-too-fond of it.
- [`gulp-mocha-phantomjs`](https://github.com/5calls/5calls/compare/master...Mr0grog:tests-with-phantomjs) This only runs tests in PhantomJS and is a bit more work on our side, though it is a little faster and lighter than Karma. I also wasted a stupid amount of time trying to get source maps working well here.
- [`mochify`](https://github.com/5calls/5calls/compare/master...Mr0grog:tests-with-mochify) is halfway in-between Karma and `gulp-mocha-phantomjs`. It’s much more configure-and-go, though getting it to work with browsers besides Phantom and Slimer is complicated (you need to get a webdriver server running), but at least it has support. I also spent a dumb amount of time fixing sourcemaps here, too :\
- [Intern](https://theintern.github.io) is a test runner I’ve been meaning to play with for a while (it supports unit tests and integration tests together in one package), but it turns out to be a little bit of a bear to use with CommonJS (it’s doable, but feels like a hack). I didn’t wind up exploring too far down this route.

Also worth noting: it turns out PhantomJS doesn’t do localization, so `number.toLocalString()` doesn’t do anything different than `number.toString()` in it. That’s actually more-or-less up-to-spec, but it’s not nice and it causes the `callcount` tests to fail. That might say more about `callcount` than it does about Phantom, though.

Anyway, if we choose to use Phantom for any tests, we’ll need to make sure to either skip the `callcount` tests in Phantom or to do some work on that module so that it functions in Phantom.