### PR TITLE
Rename test task to watch & auto-run tests to `test:watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ Edit the `appUrl` variable in `static/js/main.js` to be `http://localhost:8090` 
 ## Unit tests
 
 #### JavaScript 
-JavaScript unit tests are written using ```Mocha``` and ```Chai``` and run in the ```Karma``` test runner.
+
+JavaScript unit tests are written using ```Mocha``` and ```Chai``` and run in the ```Karma``` test runner. You must have the Google Chrome browser installed to run them.
 
 Run the unit tests with:
 
 ```npm test```
 
-Run the unit tests in watch mode with:
+If you are working on JavaScript code, you can make the tests automatically re-run whenever you change a relevant file with:
 
 ```npm run test:watch```
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.js",
   "scripts": {
     "test": "gulp test",
-    "test:watch": "gulp test --watch"
+    "test:watch": "gulp test:watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As noted in #181 by @oderby, there should have been two tasks for tests (`test` and `test:watch`) instead of one task with an optional argument (so it matches the existing gulp tasks). That PR got merged before I had a chance to make that change, hence this separate PR.