### PR TITLE
Fix function names

### DIFF
--- a/go/airtable.go
+++ b/go/airtable.go
@@ -74,7 +74,7 @@ type atContact struct {
 	atContactInfo `json:"fields"`
 }
 
-func (c *atContact) String() string { return asJson(c) }
+func (c *atContact) String() string { return asJSON(c) }
 
 func (c *atContact) toContact(cli *AirtableClient, wg *sync.WaitGroup) Contact {
 	var photourl string

--- a/go/models.go
+++ b/go/models.go
@@ -20,7 +20,7 @@ type Issue struct {
 }
 
 func (i *Issue) String() string {
-	return asJson(i)
+	return asJSON(i)
 }
 
 // Contact is a single point of contact related to an issue
@@ -37,7 +37,7 @@ type Contact struct {
 }
 
 func (c *Contact) String() string {
-	return asJson(c)
+	return asJSON(c)
 }
 
 // LocalReps are the contacts that constitute local representatives


### PR DESCRIPTION
Noticed while setting up that I was getting errors while running `go get` and `go build.` Looks like this function was recently renamed, just updated a few uses of it. 