### PR TITLE
Set contact to correct index when switching issues

### DIFF
--- a/static/js/components/call.js
+++ b/static/js/components/call.js
@@ -23,7 +23,8 @@ module.exports = (state, prev, send) => {
       </div>
     </section>`;
   }
-  const currentContact = issue.contacts[state.contactIndex];
+  const currentIndex = state.contactIndices[issue.id];
+  const currentContact = issue.contacts[currentIndex];
 
   function contactArea() {
     if (currentContact != null) {

--- a/static/js/components/call_test.js
+++ b/static/js/components/call_test.js
@@ -30,7 +30,7 @@ describe('call component', () => {
       contactIndices[id] = 0;
       issue.contacts = [contact];
       let issues = [issue];
-      let state = {issues, location, contactIndices: contactIndices, showFieldOfficeNumbers: false};
+      let state = {issues, location, contactIndices, showFieldOfficeNumbers: false};
       let result = call(state);
       let element = result.querySelector('.call__contact__name');
       expect(element.textContent).to.contain(cname);
@@ -50,7 +50,7 @@ describe('call component', () => {
       let issues = [issue];
       let contactIndices = {};
       contactIndices[id] = 0;
-      let state = {issues, location, contactIndices: contactIndices};
+      let state = {issues, location, contactIndices};
       let result = call(state);
       let element = result.querySelector('h2 a');
       // Anchor should contain 'Set your location' text content

--- a/static/js/components/call_test.js
+++ b/static/js/components/call_test.js
@@ -26,11 +26,13 @@ describe('call component', () => {
         script: 'Please vote against everything'
       };
       let contact = {name: cname, party: 'Dem'};
+      let contactIndices = {};
+      contactIndices[id] = 0;
       issue.contacts = [contact];
       let issues = [issue];
-      let state = {issues, location, contactIndex: 0, showFieldOfficeNumbers: false};
+      let state = {issues, location, contactIndices: contactIndices, showFieldOfficeNumbers: false};
       let result = call(state);
-      let element = result.querySelector('.call__contact__name')
+      let element = result.querySelector('.call__contact__name');
       expect(element.textContent).to.contain(cname);
     });
 
@@ -46,7 +48,9 @@ describe('call component', () => {
       };
       issue.contacts = [null];
       let issues = [issue];
-      let state = {issues, location, contactIndex: 0};
+      let contactIndices = {};
+      contactIndices[id] = 0;
+      let state = {issues, location, contactIndices: contactIndices};
       let result = call(state);
       let element = result.querySelector('h2 a');
       // Anchor should contain 'Set your location' text content

--- a/static/js/components/outcomes.js
+++ b/static/js/components/outcomes.js
@@ -3,9 +3,10 @@ const find = require('lodash/find');
 
 module.exports = (state, prev, send) => {
   const issue = find(state.issues, ['id', state.location.params.issueid]);
-  const currentContact = issue.contacts[state.contactIndex];
+  const currentIndex = state.contactIndices[issue.id];
+  const currentContact = issue.contacts[currentIndex];
 
-  const contactsLeft = issue.contacts.length - (state.contactIndex + 1);
+  const contactsLeft = issue.contacts.length - (currentIndex + 1);
   const callsPluralization = contactsLeft > 1 ? "people" : "person";
 
   const contactsLeftText = contactsLeft + " more " + callsPluralization +" to call for this issue.";

--- a/static/js/components/outcomes_test.js
+++ b/static/js/components/outcomes_test.js
@@ -22,7 +22,7 @@ describe('outcomes component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = outcomes(state);
       let content = result.querySelector('div.call__outcomes');
@@ -47,19 +47,19 @@ describe('outcomes component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = outcomes(state);
       expect(result).to.be.undefined;
   });
 
-  it('should have contacts left if last contact', () => {
+  it('should have contacts left if not last contact', () => {
       let cname1 = 'Senator Blowhart';
       let cname2 = 'Senator Hartblow';
       let id = 1;
       let location = {params: {issueid: id}};
       let issue = {
-        id: id, // does not match location issue id
+        id: id,
         name: 'Bozo the nominee',
         reason: 'crazy',
         script: 'Please vote against nominee Bozo'
@@ -73,7 +73,7 @@ describe('outcomes component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = outcomes(state);
       expect(result.textContent).to.contain('1 more');
@@ -85,7 +85,7 @@ describe('outcomes component', () => {
       let id = 1;
       let location = {params: {issueid: id}};
       let issue = {
-        id: id, // does not match location issue id
+        id: id,
         name: 'Bozo the nominee',
         reason: 'crazy',
         script: 'Please vote against nominee Bozo'
@@ -99,7 +99,7 @@ describe('outcomes component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = outcomes(state);
       expect(result.textContent).to.not.contain('1 more');

--- a/static/js/components/outcomes_test.js
+++ b/static/js/components/outcomes_test.js
@@ -17,10 +17,12 @@ describe('outcomes component', () => {
       let contact = {name: cname, party: 'Dem'};
       issue.contacts = [contact];
       let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 0;
       let state = {
         issues,
         location,
-        contactIndex: 0,
+        contactIndices: contactIndices,
       };
       let result = outcomes(state);
       let content = result.querySelector('div.call__outcomes');
@@ -40,11 +42,12 @@ describe('outcomes component', () => {
       let contact = {name: cname, party: 'Dem'};
       issue.contacts = [contact];
       let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 1; // contactIndex 1 does not exist
       let state = {
         issues,
         location,
-        // contactIndex 1 does not exist
-        contactIndex: 1
+        contactIndices: contactIndices,
       };
       let result = outcomes(state);
       expect(result).to.be.undefined;

--- a/static/js/components/outcomes_test.js
+++ b/static/js/components/outcomes_test.js
@@ -53,4 +53,56 @@ describe('outcomes component', () => {
       expect(result).to.be.undefined;
   });
 
+  it('should have contacts left if last contact', () => {
+      let cname1 = 'Senator Blowhart';
+      let cname2 = 'Senator Hartblow';
+      let id = 1;
+      let location = {params: {issueid: id}};
+      let issue = {
+        id: id, // does not match location issue id
+        name: 'Bozo the nominee',
+        reason: 'crazy',
+        script: 'Please vote against nominee Bozo'
+      };
+      let contact1 = {name: cname1, party: 'Dem'};
+      let contact2 = {name: cname2, party: 'Dem'};
+      issue.contacts = [contact1, contact2];
+      let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 0;
+      let state = {
+        issues,
+        location,
+        contactIndices: contactIndices,
+      };
+      let result = outcomes(state);
+      expect(result.textContent).to.contain('1 more');
+  });
+
+  it('should NOT have contacts left if last contact', () => {
+      let cname1 = 'Senator Blowhart';
+      let cname2 = 'Senator Hartblow';
+      let id = 1;
+      let location = {params: {issueid: id}};
+      let issue = {
+        id: id, // does not match location issue id
+        name: 'Bozo the nominee',
+        reason: 'crazy',
+        script: 'Please vote against nominee Bozo'
+      };
+      let contact1 = {name: cname1, party: 'Dem'};
+      let contact2 = {name: cname2, party: 'Dem'};
+      issue.contacts = [contact1, contact2];
+      let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 1;
+      let state = {
+        issues,
+        location,
+        contactIndices: contactIndices,
+      };
+      let result = outcomes(state);
+      expect(result.textContent).to.not.contain('1 more');
+  });
+
 });

--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -3,8 +3,9 @@ const find = require('lodash/find');
 const scriptLine = require('./scriptLine.js');
 
 module.exports = (state, prev, send) => {
-	  const issue = find(state.issues, ['id', state.location.params.issueid]);
-	  const currentContact = issue.contacts[state.contactIndex];
+    const issue = find(state.issues, ['id', state.location.params.issueid]);
+    const currentIndex = state.contactIndices[issue.id];
+    const currentContact = issue.contacts[currentIndex];
     
     if (currentContact != null) {
       return html`

--- a/static/js/components/script_test.js
+++ b/static/js/components/script_test.js
@@ -22,7 +22,7 @@ describe('script component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = script(state);
       let content = result.querySelector('div.call__script__body');
@@ -47,7 +47,7 @@ describe('script component', () => {
       let state = {
         issues,
         location,
-        contactIndices: contactIndices,
+        contactIndices
       };
       let result = script(state);
       expect(result).to.be.undefined;

--- a/static/js/components/script_test.js
+++ b/static/js/components/script_test.js
@@ -17,10 +17,12 @@ describe('script component', () => {
       let contact = {name: cname, party: 'Dem'};
       issue.contacts = [contact];
       let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 0;
       let state = {
         issues,
         location,
-        contactIndex: 0,
+        contactIndices: contactIndices,
       };
       let result = script(state);
       let content = result.querySelector('div.call__script__body');
@@ -40,11 +42,12 @@ describe('script component', () => {
       let contact = {name: cname, party: 'Dem'};
       issue.contacts = [contact];
       let issues = [issue];
+      let contactIndices = {};
+      contactIndices[id] = 1; // contactIndex 1 does not exist
       let state = {
         issues,
         location,
-        // contactIndex 1 does not exist
-        contactIndex: 1
+        contactIndices: contactIndices,
       };
       let result = script(state);
       expect(result).to.be.undefined;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -128,13 +128,11 @@ app.model({
       return { geolocation: geo, cachedCity: city, geoCacheTime: time, fetchingLocation: false, askingLocation: false }
     },
     setContactIndices: (state, data) => {
+      contactIndices = state.contactIndices;
       if (data.newIndex != 0) {
-        contactIndices = state.contactIndices;
         contactIndices[data.issueid] = data.newIndex;
         return { contactIndices: contactIndices }
       } else {
-        store.add("org.5calls.completed", data.issueid, () => {})
-        contactIndices = state.contactIndices;
         contactIndices[data.issueid] = 0;
         return { contactIndices: contactIndices, completedIssues: state.completedIssues.concat(data.issueid) }
       }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -96,7 +96,7 @@ app.model({
     askingLocation: false,
     fetchingLocation: cachedFetchingLocation,
     locationFetchType: cachedLocationFetchType,
-    contactIndex: 0,
+    contactIndices: {},
     completedIssues: completedIssues,
 
     showFieldOfficeNumbers: false,
@@ -108,7 +108,11 @@ app.model({
     receiveIssues: (state, data) => {
       response = JSON.parse(data)
       issues = response.issues //.filter((v) => { return v.contacts.length > 0 });
-      return { issues: issues, splitDistrict: response.splitDistrict, invalidAddress: response.invalidAddress }
+      contactIndices = {};
+      issues.forEach(function(item, index) {
+         contactIndices[item.id] = 0;
+      });
+      return { issues: issues, splitDistrict: response.splitDistrict, invalidAddress: response.invalidAddress, contactIndices: contactIndices }
     },
     receiveTotals: (state, data) => {
       totals = JSON.parse(data);
@@ -123,15 +127,16 @@ app.model({
       store.replace("org.5calls.geolocation_time", 0, time, () => {});
       return { geolocation: geo, cachedCity: city, geoCacheTime: time, fetchingLocation: false, askingLocation: false }
     },
-    changeActiveIssue: (state, issueId) => {
-      return { contactIndex: 0 }
-    },
-    setContactIndex: (state, data) => {
+    setContactIndices: (state, data) => {
       if (data.newIndex != 0) {
-        return { contactIndex: data.newIndex }
+        contactIndices = state.contactIndices;
+        contactIndices[data.issueid] = data.newIndex;
+        return { contactIndices: contactIndices }
       } else {
         store.add("org.5calls.completed", data.issueid, () => {})
-        return { contactIndex: 0, completedIssues: state.completedIssues.concat(data.issueid) }
+        contactIndices = state.contactIndices;
+        contactIndices[data.issueid] = 0;
+        return { contactIndices: contactIndices, completedIssues: state.completedIssues.concat(data.issueid) }
       }
     },
     setAddress: (state, address) => {
@@ -317,14 +322,15 @@ app.model({
     incrementContact: (state, data, send, done) => {
       const issue = find(state.issues, ['id', data.issueid]);
 
-      if (state.contactIndex < issue.contacts.length - 1) {
+      currentIndex = state.contactIndices[issue.id];
+      if (currentIndex < issue.contacts.length - 1) {
         scrollIntoView(document.querySelector('#contact'));
-        send('setContactIndex', { newIndex: state.contactIndex + 1, issueid: issue.id }, done)
+        send('setContactIndices', { newIndex: currentIndex + 1, issueid: issue.id }, done);
       } else {
         scrollIntoView(document.querySelector('#content'));
         store.add("org.5calls.completed", issue.id, () => {})
         send('location:set', "/#done/" + issue.id, done)
-        send('setContactIndex', { newIndex: 0, issueid: issue.id }, done)
+        send('setContactIndices', { newIndex: 0, issueid: issue.id }, done);
       }
     },
     callComplete: (state, data, send, done) => {


### PR DESCRIPTION
## Summary
Fixes issue [`#166`](https://github.com/5calls/5calls/issues/166)

Previously a single state variable `contactIndex` was used for all issues, even though each issue should have its own current index. This PR replaces `contactIndex` with `contactIndices`, an object that maps an issue's id to its current index.

## Testing
Manual testing and updated unit tests
![5calls](https://cloud.githubusercontent.com/assets/5424713/23007750/4cf42268-f3d0-11e6-905d-9f2f0f3bf98d.gif)

## Risks
Only frontend changes, should be relatively low risk.
I also removed the `changeActiveIssue` function in `main.js` because it wasn't being used anywhere, and it seemed like it was intended for the original bug.