### PR TITLE
Fix gulp task 'test:watch' to work.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,14 +112,14 @@ gulp.task('extra', function() {
     .pipe(gulp.dest(DEST.html));
 });
 
-function runKarmaTests ({singleRun, configFile}) {
+function runKarmaTests ({singleRun, configFile} = {}) {
   return new Promise((resolve, reject) => {
     const karmaArguments = ['start'];
-    
+
     if (configFile) {
       karmaArguments.push(configFile);
     }
-    
+
     if (singleRun) {
       karmaArguments.push('--single-run');
     }


### PR DESCRIPTION
Just a tiny error made the "test:watch" task break. Must of occurred with all the shuffling that happened to land the CI PR.