### PR TITLE
Fix support check that skips tests on ALL browsers

### DIFF
--- a/static/js/components/callcount_test.js
+++ b/static/js/components/callcount_test.js
@@ -4,12 +4,12 @@ const chai = require('chai');
 const expect = chai.expect;
 
 // Skip a test if the browser does not support locale-based number formatting
-function ifLocaleSupportedIt (test) {
+function ifLocaleSupportedIt (name, test) {
   if (window.Intl && window.Intl.NumberFormat) {
-    it(test);
+    it(name, test);
   }
   else {
-    it.skip(test);
+    it.skip(name, test);
   }
 }
 


### PR DESCRIPTION
Mistake and poor checking on my part in #200.

@nickoneill No offense, but maybe it would be good to have a policy of requiring at least one reviewer with a clear understanding of what the code is doing give a 👍 before merging? Would help mitigate dumb mistakes like this.