### PR TITLE
Use loglevel module for JS logging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,7 @@ function runKarmaTests ({singleRun, configFile} = {}) {
   });
 }
 
-gulp.task('test', function() {
+gulp.task('test:js-unit', function() {
   return runKarmaTests({singleRun: true});
 });
 
@@ -155,9 +155,32 @@ gulp.task('test:watch', function() {
 // Designed for running tests in continuous integration. The main difference
 // here is that browser tests are run across a gamut of browsers/platforms via
 // Sauce Labs instead of just a few locally.
-gulp.task('test:ci', function() {
+gulp.task('test:ci', ['eslint'], function() {
   return runKarmaTests({configFile: 'karma.ci.conf.js'});
 });
+
+gulp.task('eslint', function() {
+  const eslint = require('eslint');
+  const linter = new eslint.CLIEngine();
+  const report = linter.executeOnFiles(['./static']);
+  
+  // customize messages to be a little more helpful/friendly
+  report.results.forEach(result => {
+    result.messages.forEach(message => {
+      if (message.ruleId === 'no-console') {
+        message.message = 'Please use the `loglevel` module for logging instead of the browser `console` object';
+      }
+    });
+  });
+
+  process.stdout.write(linter.getFormatter()(report.results));
+  if (report.errorCount) {
+    return Promise.reject(
+      new util.PluginError('ESLint', 'Found problems with JS coding style.'));
+  }
+});
+
+gulp.task('test', ['eslint', 'test:js-unit']);
 
 gulp.task('default', ['html', 'html:watch', 'html:serve', 'sass', 'sass:watch', 'copy-images', 'copy-images:watch', 'scripts', 'scripts:watch', 'extra']);
 gulp.task('deploy', ['html', 'sass', 'build-scripts', 'extra', 'copy-images']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -175,8 +175,7 @@ gulp.task('eslint', function() {
 
   process.stdout.write(linter.getFormatter()(report.results));
   if (report.errorCount) {
-    return Promise.reject(
-      new util.PluginError('ESLint', 'Found problems with JS coding style.'));
+    throw new util.PluginError('ESLint', 'Found problems with JS coding style.');
   }
 });
 

--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -46,14 +46,12 @@ module.exports = function (configuration) {
       platform: 'Windows 7',
       version: '11.0'
     },
-    
-    // FIXME: temporarily disable IE 10 because of console.log calls
-    // sauce_ie_10_windows_7: {
-    //   base: 'SauceLabs',
-    //   browserName: 'internet explorer',
-    //   platform: 'Windows 7',
-    //   version: '10.0'
-    // },
+    sauce_ie_10_windows_7: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 7',
+      version: '10.0'
+    },
 
     // Latest two Safaris
     sauce_safari: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'static/test/setupUnitTests.js',
       'static/js/**/*_test.js'
     ],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "browserify": "^13.1.1",
     "chai": "^3.5.0",
     "es2040": "^1.2.4",
+    "eslint": "^3.15.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
     "gulp-imagemin": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gulp-util": "^3.0.8",
     "http-server": "^0.9.0",
     "lodash": "^4.17.2",
+    "loglevel": "^1.4.1",
     "query-string": "^4.2.3",
     "scroll-into-view": "^1.7.1",
     "xhr": "^2.3",

--- a/static/.eslintrc.json
+++ b/static/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 7,
+    "sourceType": "module"
+  },
+  "env": {
+    "browser": true,
+    "commonjs": true
+  },
+  "rules": {
+    "no-console": "error"
+  }
+}

--- a/static/js/components/contact.js
+++ b/static/js/components/contact.js
@@ -1,10 +1,11 @@
 const html = require('choo/html');
 const find = require('lodash/find');
+const logger = require('loglevel');
 
 module.exports = (c, state, prev, send) => {
   const photoURL = c.photoURL == "" ? "/img/5calls-icon-office.png" : c.photoURL;
   if (c.reason == "") {
-    console.debug("Missing reason for contact " + c.name)
+    logger.debug("Missing reason for contact " + c.name)
   }
 
   repID = ""

--- a/static/js/components/contact_test.js
+++ b/static/js/components/contact_test.js
@@ -19,7 +19,6 @@ describe('contact component', () => {
       showFieldOfficeNumbers: false
     };
     let result = contact(contactData, state);
-    // console.log("RESULT", result);
     expect(result.querySelector('.call__contact__name').textContent).to.contain(contactData.name);
   });
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -14,8 +14,9 @@ const appURL = 'https://5calls.org';
 // use localStorage directly to set this value *before* bootstrapping the app.
 const debug = (localStorage['org.5calls.debug'] === 'true');
 
-if (!debug) {
-  logger.setDefaultLevel(logger.levels.WARN);
+if (debug) {
+  // we don't need loglevel's built-in persistence; we do it ourselves above ^
+  logger.setLevel(logger.levels.TRACE, false);
 }
 
 // get the stored zip location

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -2,6 +2,7 @@ const choo = require('choo');
 const html = require('choo/html');
 const http = require('xhr');
 const find = require('lodash/find');
+const logger = require('loglevel');
 const queryString = require('query-string');
 const store = require('./utils/localstorage.js');
 const scrollIntoView = require('scroll-into-view');
@@ -14,7 +15,7 @@ const appURL = 'https://5calls.org';
 const debug = (localStorage['org.5calls.debug'] === 'true');
 
 if (!debug) {
-  console.debug = () => {};
+  logger.setDefaultLevel(logger.levels.WARN);
 }
 
 // get the stored zip location
@@ -29,7 +30,7 @@ store.getAll('org.5calls.location', (location) => {
 cachedGeo = '';
 store.getAll('org.5calls.geolocation', (geo) => {
   if (geo.length > 0) {
-    console.debug("geo get", geo[0]);
+    logger.debug("geo get", geo[0]);
     cachedGeo = geo[0]
   }
 });
@@ -40,7 +41,7 @@ let cachedFetchingLocation = (cachedGeo === '') ? true : false;
 cachedAllowBrowserGeo = true;
 store.getAll('org.5calls.allow_geolocation', (allowGeo) => {
   if (allowGeo.length > 0) {
-    console.debug("allowGeo get", allowGeo[0]);
+    logger.debug("allowGeo get", allowGeo[0]);
     cachedAllowBrowserGeo = allowGeo[0]
   }
 });
@@ -51,7 +52,7 @@ let cachedLocationFetchType = (cachedAllowBrowserGeo) ? 'browserGeolocation' : '
 cachedGeoTime = '';
 store.getAll('org.5calls.geolocation_time', (geo) => {
   if (geo.length > 0) {
-    console.debug("geo time get", geo[0]);
+    logger.debug("geo time get", geo[0]);
     cachedGeoTime = geo[0]
   }
 });
@@ -59,7 +60,7 @@ store.getAll('org.5calls.geolocation_time', (geo) => {
 cachedCity = '';
 store.getAll('org.5calls.geolocation_city', (city) => {
   if (city.length > 0) {
-    console.debug("city get", city[0]);
+    logger.debug("city get", city[0]);
     cachedCity = city[0]
   }
 });
@@ -196,7 +197,7 @@ app.model({
       }
 
       const issueURL = appURL+'/issues/'+address
-      // console.debug("fetching url",issueURL);
+      logger.debug("fetching url",issueURL);
       http(issueURL, (err, res, body) => {
         send('setCachedCity', body, done)
         send('receiveIssues', body, done)
@@ -268,11 +269,11 @@ app.model({
             send('allowBrowserGeolocation', true, done);
             send('setBrowserGeolocation', geo, done);
           } else {
-            console.warn("Error: bad browser location results");
+            logger.warn("Error: bad browser location results");
             send('fetchLocationBy', 'ipAddress', done);
           }
         } else {
-          console.warn("Error: bad browser location results");
+          logger.warn("Error: bad browser location results");
           send('fetchLocationBy', 'ipAddress', done);
         }
       }
@@ -281,7 +282,7 @@ app.model({
 
         // We need the most current state, so we need another effect call.
         send('handleBrowserLocationError', error, done)
-        console.warn("Error with browser location (code: " + error.code + ")");
+        logger.warn("Error with browser location (code: " + error.code + ")");
       }
       let handleSlowResponse = function() {
         send('fetchLocationBy', 'ipAddress', done);

--- a/static/test/setupUnitTests.js
+++ b/static/test/setupUnitTests.js
@@ -1,0 +1,7 @@
+/**
+ * Setup script for unit testing. Any configuration specific to test
+ * environments should be included here.
+ */
+
+const logger = require('loglevel');
+logger.setLevel(logger.levels.TRACE, false);


### PR DESCRIPTION
This addresses #201 and allows us to turn IE 10 back on for testing.

There are other ways to handle this and modules we could use besides [loglevel](https://www.npmjs.com/package/loglevel), but I think it’s a good, simple one (and I have experience with it). Happy to close this is others prefer something else.