### PR TITLE
Fix #197 - add support for rendering call count on Safari

### DIFF
--- a/static/js/components/callcount.js
+++ b/static/js/components/callcount.js
@@ -8,9 +8,12 @@ module.exports = (state, prev, send) => {
   `;
 
   function callCount(state) {
-    const calls = Number(state.totalCalls);
+    let calls = Number(state.totalCalls);
+    // Handle undefined input.
+    // Number(undefined) is NaN, while Number("") is 0
+    calls = isNaN(calls) ? 0 : calls;
     // Number.toLocaleString() doesn't work on Safari 9 (see https://github.com/5calls/5calls/issues/197)
-    if (!!window.Intl && typeof Intl.NumberFormat == 'function') {
+    if (window.Intl && typeof Intl.NumberFormat == 'function') {
       return calls.toLocaleString();
     } else {
       // As a fallback, use a quick-and-dirty regex to insert commas.

--- a/static/js/components/callcount.js
+++ b/static/js/components/callcount.js
@@ -3,7 +3,19 @@ const html = require('choo/html');
 module.exports = (state, prev, send) => {
   return html`
   <h2 class="callcount" onload=${(e) => send('getTotals')}>
-    Together we’ve made ${Number(state.totalCalls).toLocaleString()} calls
+    Together we’ve made ${callCount(state)} calls
   </h2>
   `;
+
+  function callCount(state) {
+    const calls = Number(state.totalCalls);
+    // Number.toLocaleString() doesn't work on Safari 9 (see https://github.com/5calls/5calls/issues/197)
+    if (!!window.Intl && typeof Intl.NumberFormat == 'function') {
+      return calls.toLocaleString();
+    } else {
+      // As a fallback, use a quick-and-dirty regex to insert commas.
+      // When in doubt, get code from stackoverflow: http://stackoverflow.com/a/2901298/7542666
+      return calls.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    }
+  }
 }

--- a/static/js/components/callcount_test.js
+++ b/static/js/components/callcount_test.js
@@ -3,24 +3,14 @@ const callcount = require('./callcount.js');
 const chai = require('chai');
 const expect = chai.expect;
 
-// Skip a test if the browser does not support locale-based number formatting
-function ifLocaleSupportedIt (name, test) {
-  if (window.Intl && window.Intl.NumberFormat) {
-    it(name, test);
-  }
-  else {
-    it.skip(name, test);
-  }
-}
-
 describe('callcount component', () => {
-  ifLocaleSupportedIt('should properly format call total >=1000 with commas', () => {
+  it('should properly format call total >=1000 with commas', () => {
     let state = {totalCalls: '123456789'};
     let result = callcount(state);
     expect(result.textContent).to.contain('123,456,789');
   });
 
-  ifLocaleSupportedIt('should properly format call total < 1000 without commas', () => {
+  it('should properly format call total < 1000 without commas', () => {
     const totals = '123';
     let state = {totalCalls: totals};
     let result = callcount(state);
@@ -28,7 +18,7 @@ describe('callcount component', () => {
     expect(result.textContent).to.not.contain(',');
   });
 
-  ifLocaleSupportedIt('should not format zero call total', () => {
+  it('should not format zero call total', () => {
     const totals = '0';
     let state = {totalCalls: totals};
     let result = callcount(state);

--- a/static/js/components/callcount_test.js
+++ b/static/js/components/callcount_test.js
@@ -26,4 +26,17 @@ describe('callcount component', () => {
     expect(result.textContent).to.not.contain(',');
   });
 
+  it('should properly handle undefined state', () => {
+    let state = {totalCalls: undefined};
+    let result = callcount(state);
+    expect(result.textContent).to.contain('0');
+    expect(result.textContent).not.to.not.contain('NaN');
+  });
+
+  it('should properly handle empty state', () => {
+    let state = {totalCalls: ""};
+    let result = callcount(state);
+    expect(result.textContent).to.contain('0');
+    expect(result.textContent).not.to.not.contain('NaN');
+  });
 });


### PR DESCRIPTION
Given that we have a restricted subset of the toLocaleString
functionality we need (just inserting thousands separator) and
we only support a single locale now ('en') and that we are a
US-centric app, I decided to just special case handling in
the component for now.