### PR TITLE
typo - missing quote and slash on href value.

### DIFF
--- a/static/js/components/issuesListItem.js
+++ b/static/js/components/issuesListItem.js
@@ -36,7 +36,7 @@ module.exports = (issue, state, prev, send) => {
 
   return html`
     <li onclick=${handleClick}>
-      <a aria-controls="content" class="${classString(state, '')}" href=#issue${issue.id}">
+      <a aria-controls="content" class="${classString(state, '')}" href="#issue/${issue.id}">
         <span aria-live="polite" class="${classString(state, '__status')}"><span class="visually-hidden">${statusText}</span></span>
         <span class="${classString(state, '__title')}">${issue.name}</span>
         <span class="${classString(state, '__summary')}">${issue.contacts.length} call${ issue.contacts.length > 1 ? "s" : "" } to make</span>


### PR DESCRIPTION
Introduced here: https://github.com/5calls/5calls/commit/6e4341390876c2936ac528bfd2b560655a9292db#diff-13f2f55f8c5ad0a842db049e9f8b0caaR27

cc @liamdanger 