### PR TITLE
Remove duplicate navigation when selecting issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "loglevel": "^1.4.1",
     "query-string": "^4.2.3",
     "scroll-into-view": "^1.7.1",
+    "sheet-router": "^4.2.3",
     "xhr": "^2.3",
     "xtend": "^4.0.1"
   }

--- a/static/js/components/issuesListItem.js
+++ b/static/js/components/issuesListItem.js
@@ -22,11 +22,7 @@ module.exports = (issue, state, prev, send) => {
   }
 
   function issueIsCompleted(state, issue) {
-    if (state.completedIssues.indexOf(issue.id) != -1) {
-      return true;
-    } else {
-      return false;
-    }
+    return state.completedIssues.indexOf(issue.id) != -1;
   }
 
   let statusText = "";

--- a/static/js/components/issuesListItem_test.js
+++ b/static/js/components/issuesListItem_test.js
@@ -4,19 +4,17 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe('issuesListItem component', () => {
+  const issue = {
+    id: 99,
+    name: 'Impeach Trump',
+    contacts: [{id:88,name:'mccain'}]
+  };
+  const location = {params:[{issueId:100}]};
 
   it('should display issue name and number of calls to make', () => {
-    let issue = {
-      id: 99,
-      name: 'Impeach Trump',
-      contacts: [{id:88,name:'mccain'}],
-    };
-    let location = {params:[{issueId:100}]};
-    let state = {completedIssues: [], location};
-    let sendCalled = false;
-    let send = (name, objWithId) =>  sendCalled = true;
-    let results = issuesListItem(issue, state, null, send);
-    let spans = results.querySelectorAll('span');
+    const state = {completedIssues: [], location};
+    const results = issuesListItem(issue, state);
+    const spans = results.querySelectorAll('span');
 
     expect(spans.length).to.not.equal(0);
     // nothing
@@ -29,18 +27,24 @@ describe('issuesListItem component', () => {
   });
 
   it('should display statusText of "Done" since there are completed issues', () => {
-    let issue = {
-      id: 99,
-      name: 'Impeach Trump',
-      contacts: [{id:88,name:'mccain'}],
-    };
-    let location = {params:[{issueId:100}]};
-    let state = {completedIssues: [99], location};
-    let sendCalled = false;
-    let send = (name, objWithId) =>  sendCalled = true;
-    let results = issuesListItem(issue, state, null, send);
-    let span = results.querySelector('span.visually-hidden');
+    const state = {completedIssues: [99], location};
+    const results = issuesListItem(issue, state);
+    const span = results.querySelector('span.visually-hidden');
     expect(span.textContent).to.contain("Done");
   });
 
+  it("should send 'activateIssue' event when clicked", () => {
+    const state = {completedIssues: [], location};
+    let sendCalled = false;
+    let sentId = undefined;
+    let send = (name, objWithId) =>  {
+      sendCalled = true;
+      sentId = objWithId;
+    };
+    const results = issuesListItem(issue, state, null, send);
+    expect(sendCalled).to.be.false;
+    results.click();
+    expect(sendCalled).to.be.true;
+    expect(sentId).to.deep.equal({id: issue.id});
+  });
 });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -6,6 +6,7 @@ const logger = require('loglevel');
 const queryString = require('query-string');
 const store = require('./utils/localstorage.js');
 const scrollIntoView = require('scroll-into-view');
+const onHashChange = require('sheet-router/hash');
 
 const app = choo();
 const appURL = 'https://5calls.org';
@@ -370,15 +371,27 @@ app.model({
       ga('send', 'event', 'issue_flow', 'select', 'select');
 
       scrollIntoView(document.querySelector('#content'));
-
-      // Use Choo's internal model to control Window.location. Fixes issue #161
-      // For more information, see: https://github.com/yoshuawuyts/choo/blob/f84ec43fa58508cc20fe537d752a14901339f0cd/README.md#router
-      // this strips the query string which breaks hashes, so temp workaround
-      send('location:set', "/#issue/" + data.id, done)
-      // location = location.origin + "#issue/" + data.id;
-      // location.hash = "issue/" + data.id;
     }
   },
+  subscriptions: {
+    // Workaround for bugs in choo and IE when using hash routes.
+    // Problem: Choo's internal handlers for updating the internal location model
+    // do not work properly with hash routes on IE, due to two separate bugs:
+    //  1. popstate event is not fired when only the hash changes (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/3740423/)
+    //     meaning the internal history handler doesn't fire.
+    //  2. the href handling logic has a bug (https://github.com/yoshuawuyts/sheet-router/issues/82)
+    //     so the internal href handler also doesn't fire
+    // The result of these two issues is that when a user clicks on an issue
+    // in our app on IE, the URL in the browser changes, but the app doesn't
+    // update to render the new view.
+    // Solution: We explicitly esnure choo's internal location model is correct
+    // by forcing it to update any time the hash in the route changes.
+    handleHashChange: function (send, done) {
+      onHashChange(function navigate (href) {
+        send('location:touch', href, done);
+      });
+    }
+  }
 });
 
 app.router({ default: '/' }, [

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -384,7 +384,7 @@ app.model({
     // The result of these two issues is that when a user clicks on an issue
     // in our app on IE, the URL in the browser changes, but the app doesn't
     // update to render the new view.
-    // Solution: We explicitly esnure choo's internal location model is correct
+    // Solution: We explicitly ensure choo's internal location model is correct
     // by forcing it to update any time the hash in the route changes.
     handleHashChange: function (send, done) {
       onHashChange(function navigate (href) {


### PR DESCRIPTION
This fixes an issue where, after selecting an issue,
it would take two presses of the browser back button
to navigate back to the previous page. This issue was
uncovered (indirectly) while triaging #216.

Improved unit test coverage, but, as per discussion
in #219, we should add an e2e test to verify that
clicking on the link successfully navigates to the
issue.