### PR TITLE
Default to the home page if passed an invalid route.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -381,7 +381,7 @@ app.model({
   },
 });
 
-app.router({ default: '/404' }, [
+app.router({ default: '/' }, [
   ['/', require('./pages/mainView.js')],
   ['/issue', require('./pages/mainView.js'),
     [':issueid', require('./pages/mainView.js')]


### PR DESCRIPTION
This fixes the second error seen in #216

Note, this only effects bad urls (#fooabare) that aren't defined
routes. Non-existent issues (e.g. /#issue/foo) are still valid
routes, and so don't trigger the default behavior.