### PR TITLE
Run Gulp commands through npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Front end requirements must first be installed with:
 
 To start developing:
 
-`npm run develop`
+`npm start`
 
 This command will:
 
@@ -41,7 +41,7 @@ To package assets for deployment:
 
 `npm run deploy`
 
-This command also builds the assets, but does not watch for changes, and applies additional transforms on the assets -- such as an uglify transform on Javascript sources.
+This command also builds the assets, applies additional transforms on the assets (such as minification of the JavaScript sources), but does not watch for changes.
 
 To turn on/off debug mode, which adds some reset buttons throughout the interface, run the following in your console:
 

--- a/README.md
+++ b/README.md
@@ -27,22 +27,21 @@ Front end requirements must first be installed with:
 
 `npm install`
 
-Gulp is used to compile front end static assets. If you do not have Gulp
-installed globally, you can install this with:
+To start developing:
 
-`npm install -g gulp`
+`npm run develop`
 
-Gulp is configured, by default, to watch and recompile front end files when
-any changes are detected. You can run Gulp in this mode with:
+This command will:
 
-`gulp`
+* compile front end static assets
+* spin up an HTTP server for serving the site files on port `tcp/8000`.
+* watch and recompile front end files when any changes are detected
 
-This default command will also spin up an HTTP server for serving the site
-files on port `tcp/8000`.
+To package assets for deployment:
 
-The other main Gulp task is the `deploy` task, which does not watch for
-changes, and applies additional transforms on the assets -- such as an uglify
-transform on Javascript sources.
+`npm run deploy`
+
+This command also builds the assets, but does not watch for changes, and applies additional transforms on the assets -- such as an uglify transform on Javascript sources.
 
 To turn on/off debug mode, which adds some reset buttons throughout the interface, run the following in your console:
 

--- a/README.md
+++ b/README.md
@@ -27,22 +27,21 @@ Front end requirements must first be installed with:
 
 `npm install`
 
-Gulp is used to compile front end static assets. If you do not have Gulp
-installed globally, you can install this with:
+To start developing:
 
-`npm install -g gulp`
+`npm run develop`
 
-Gulp is configured, by default, to watch and recompile front end files when
-any changes are detected. You can run Gulp in this mode with:
+This will:
 
-`gulp`
+* compile front end static assets
+* spin up an HTTP server for serving the site files on port `tcp/8000`.
+* watch and recompile front end files when any changes are detected
 
-This default command will also spin up an HTTP server for serving the site
-files on port `tcp/8000`.
+To package assets for deployment:
 
-The other main Gulp task is the `deploy` task, which does not watch for
-changes, and applies additional transforms on the assets -- such as an uglify
-transform on Javascript sources.
+`npm run deploy`
+
+This does not watch for changes, and applies additional transforms on the assets -- such as an uglify transform on Javascript sources.
 
 To turn on/off debug mode, which adds some reset buttons throughout the interface, run the following in your console:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "gulpfile.js",
   "scripts": {
-    "develop": "gulp",
+    "start": "gulp",
     "deploy": "gulp deploy",
     "test": "gulp test",
     "test:watch": "gulp test:watch"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "gulpfile.js",
   "scripts": {
+    "develop": "gulp",
+    "deploy": "gulp deploy",
     "test": "gulp test",
     "test:watch": "gulp test:watch"
   },


### PR DESCRIPTION
This pull request aliases the existing Gulp commands to npm scripts and replaces text in the README.md about installing Gulp globally with the new npm commands.

Running commands via npm scripts adds the `node_modules/.bin/` to the PATH, exposing the locally installed Gulp, so it does not have to be installed globally.

This approach (very) slightly simplifies the README.md and  developer setup.