### PR TITLE
small fix to app icons in IE 11

### DIFF
--- a/static/scss/_hypothesis.scss
+++ b/static/scss/_hypothesis.scss
@@ -49,11 +49,11 @@
     }
 
     .ios {
-      padding: 12px 0 0 0;
-      width: 174px;
+      padding: 9px 0 0 0;
+      width: auto;
     }
     .play {
-      width: 200px;
+      width: 150px;
     }
   }
 }


### PR DESCRIPTION
Currently, when you load 5calls.org on IE 11, you see the IOS app icon is stretched and misaligned:
![image](https://cloud.githubusercontent.com/assets/1351158/23574443/4e08fcf4-0033-11e7-9f5a-a22c6c72cddb.png)

This seems like a bug in IE to me, and this change works around the issue. However, I'll admit I'm not really a CSS guru, so I'm not sure what exactly is wrong or if this is the best fix.