### PR TITLE
Add null check and clean up

### DIFF
--- a/static/js/components/issues.js
+++ b/static/js/components/issues.js
@@ -1,5 +1,5 @@
 const html = require('choo/html');
-const scrollIntoView = require('scroll-into-view');
+const scrollIntoView = require('../utils/scrollIntoView.js');
 
 const issuesHeader = require('./issuesHeader.js');
 const issuesList = require('./issuesList.js');

--- a/static/js/utils/scrollIntoView.js
+++ b/static/js/utils/scrollIntoView.js
@@ -3,8 +3,10 @@ require('smoothscroll-polyfill').polyfill();
 
 // Uses window scroll instead of element.scrollIntoView
 function scrollIntoView (element) {
-  const scrollY = element.getBoundingClientRect().top + (window.scrollY || window.pageYOffset);
-  window.scroll({ top: scrollY, left: 0, behavior: 'smooth' });
+  if (element){
+    const scrollY = element.getBoundingClientRect().top + (window.scrollY || window.pageYOffset);
+    window.scroll({ top: scrollY, left: 0, behavior: 'smooth' });
+  }
 }
 
 // smoothscroll wrapper


### PR DESCRIPTION
## Summary
Leftover changes to [#208](https://github.com/5calls/5calls/issues/208)

Adds null check to `scrollIntoView.js` in case the element is invalid.
Removes last usage of old dependency.