### PR TITLE
[emergency fix] Add missing raf and scroll-into-view dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "lodash": "^4.17.2",
     "loglevel": "^1.4.1",
     "query-string": "^4.2.3",
+    "raf": "^3.3.0",
+    "scroll-into-view": "^1.7.5",
     "smoothscroll-polyfill": "^0.3.4",
     "xhr": "^2.3",
     "xtend": "^4.0.1"


### PR DESCRIPTION
The CI build against master failed last night due to missing `raf` and `scroll-into-view` dependencies. This PR adds those dependencies to `package.json`.

@nickoneill (or any other team member with sufficient privileges) please review and merge this PR into master as soon as possible. Thank you.
