### PR TITLE
Changed urls to remove hashes.

### DIFF
--- a/static/html/index.html
+++ b/static/html/index.html
@@ -114,7 +114,7 @@
         <a href="mailto:make5calls@gmail.com">
           <i class="fa fa-envelope" aria-hidden="true"></i> Contact
         </a>
-        <a href="#about">
+        <a href="/about">
           <i class="fa fa-heart" aria-hidden="true"></i> About
         </a>
         <a href="https://5calls.zendesk.com/hc/en-us/sections/115000760947-FAQ">

--- a/static/js/components/done.js
+++ b/static/js/components/done.js
@@ -15,7 +15,7 @@ module.exports = (state, prev, send) => {
         </p>
         ${promote(state, prev, send)}
 
-        <p class="call__text"> <a href="#about">Learn why calling</a> representatives is the most effective way of making your voice heard.</p>
+        <p class="call__text"> <a href="/about">Learn why calling</a> representatives is the most effective way of making your voice heard.</p>
 
         ${callcount(state, prev, send)}
 

--- a/static/js/components/hypothesis.js
+++ b/static/js/components/hypothesis.js
@@ -16,7 +16,7 @@ module.exports = (state, prev, send) => {
       </header>
 
       <div class="hypothesis__text">
-        <p>Calling is the most effective way to influence your representative. Read more about <a href="#about">why calling works.</a>
+        <p>Calling is the most effective way to influence your representative. Read more about <a href="/about">why calling works.</a>
         </p>
 
         <h3 class="hypothesis__subtitle">5 Calls:</h3>

--- a/static/js/components/issues.js
+++ b/static/js/components/issues.js
@@ -21,7 +21,7 @@ module.exports = (state, prev, send) => {
     <div class="issues">
       ${issuesHeader(state, prev, send)}
       ${issuesList(state, prev, send)}
-      <a href="#issues" class="issues__footer-link" onclick=${scrollToTop}>view more issues</a>
+      <a href="/more" class="issues__footer-link" onclick=${scrollToTop}>view more issues</a>
       ${debugText(state.debug)}
     </div>
   `;

--- a/static/js/components/issuesListItem.js
+++ b/static/js/components/issuesListItem.js
@@ -16,11 +16,6 @@ module.exports = (issue, state, prev, send) => {
 
     return classes.join(' ');
   }
-
-  function handleClick() {
-    send("activateIssue", { id: issue.id });
-  }
-
   function issueIsCompleted(state, issue) {
     if (state.completedIssues.indexOf(issue.id) != -1) {
       return true;
@@ -35,8 +30,8 @@ module.exports = (issue, state, prev, send) => {
   }
 
   return html`
-    <li onclick=${handleClick}>
-      <a aria-controls="content" class="${classString(state, '')}" href="/issue/${issue.id}">
+    <li>
+      <a aria-controls="content" class="${classString(state, '')}" href="/issue/${issue.id}" onclick=${() => send('trackSwitchIssue')}>
         <span aria-live="polite" class="${classString(state, '__status')}"><span class="visually-hidden">${statusText}</span></span>
         <span class="${classString(state, '__title')}">${issue.name}</span>
         <span class="${classString(state, '__summary')}">${issue.contacts.length} call${ issue.contacts.length > 1 ? "s" : "" } to make</span>

--- a/static/js/components/issuesListItem.js
+++ b/static/js/components/issuesListItem.js
@@ -36,7 +36,7 @@ module.exports = (issue, state, prev, send) => {
 
   return html`
     <li onclick=${handleClick}>
-      <a aria-controls="content" class="${classString(state, '')}" href="#issue/${issue.id}">
+      <a aria-controls="content" class="${classString(state, '')}" href="/issue/${issue.id}">
         <span aria-live="polite" class="${classString(state, '__status')}"><span class="visually-hidden">${statusText}</span></span>
         <span class="${classString(state, '__title')}">${issue.name}</span>
         <span class="${classString(state, '__summary')}">${issue.contacts.length} call${ issue.contacts.length > 1 ? "s" : "" } to make</span>

--- a/static/js/components/promote.js
+++ b/static/js/components/promote.js
@@ -15,7 +15,7 @@ module.exports = (state) => {
 
   // for selected issues, customize the share text a bit more
   if (issue) {
-    url = encodeURIComponent('http://5calls.org/#issue/' + issue.id)
+    url = encodeURIComponent('http://5calls.org/issue/' + issue.id)
     // the additional "via @make5calls" text that the via param introduces doesn't fit with issue titles, remove it
     additionalTwitterComps = ""
     tweet = encodeURIComponent('I just called my rep to ' + issue.name.substring(0, 72) +

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -374,7 +374,7 @@ app.model({
       } else {
         scrollIntoView(document.querySelector('#content'));
         store.add("org.5calls.completed", issue.id, () => {})
-        send('location:set', "/#done/" + issue.id, done)
+        send('location:set', "/done/" + issue.id, done)
         send('setContactIndices', { newIndex: 0, issueid: issue.id }, done);
       }
     },
@@ -410,7 +410,7 @@ app.model({
       // Use Choo's internal model to control Window.location. Fixes issue #161
       // For more information, see: https://github.com/yoshuawuyts/choo/blob/f84ec43fa58508cc20fe537d752a14901339f0cd/README.md#router
       // this strips the query string which breaks hashes, so temp workaround
-      send('location:set', "/#issue/" + data.id, done)
+      send('location:set', "/issue/" + data.id, done)
       // location = location.origin + "#issue/" + data.id;
       // location.hash = "issue/" + data.id;
     }
@@ -426,7 +426,7 @@ app.router({ default: '/' }, [
     [':issueid', require('./pages/doneView.js')]
   ],
   ['/about', require('./pages/aboutView.js')],
-  ['/issues', require('./pages/issuesView.js')],
+  ['/more', require('./pages/issuesView.js')],
 ]);
 
 const tree = app.start();

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -400,19 +400,12 @@ app.model({
 
       send('incrementContact', data, done);
     },
-    activateIssue: (state, data, send, done) => {
+    trackSwitchIssue: (state, data, send, done) => {
       send('hideFieldOfficeNumbers', data, done);
 
       ga('send', 'event', 'issue_flow', 'select', 'select');
 
       scrollIntoView(document.querySelector('#content'));
-
-      // Use Choo's internal model to control Window.location. Fixes issue #161
-      // For more information, see: https://github.com/yoshuawuyts/choo/blob/f84ec43fa58508cc20fe537d752a14901339f0cd/README.md#router
-      // this strips the query string which breaks hashes, so temp workaround
-      send('location:set', "/issue/" + data.id, done)
-      // location = location.origin + "#issue/" + data.id;
-      // location.hash = "issue/" + data.id;
     }
   },
 });


### PR DESCRIPTION
This change modifies the links to point to non-hash urls. I think I got all of them. We're also routing the more issues page to `/more` rather than `/issues` so we don't conflict with the api path.

When running the client with `gulp`, this will route to appropriate urls but reloading those urls will result in 404s. I'm not sure if we can modify the gulp script for testing to do a better job here?

In production, the go backend will automatically route this links correctly, even when reloading. This change is live now and you can remove any hash from links to see the correct behavior.