### PR TITLE
add coverage folder to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 app/*
+coverage/*


### PR DESCRIPTION
This just removes the files from the coverage folder, that are created by the Istanbul code coverage package, from the linting process.  sslint is currently failing the tests because of the files in this folder.