### PR TITLE
Adds sending `via` parameter with call report

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -425,7 +425,10 @@ app.model({
 
       send('setUserStats', data, done);
       
+      // This parameter will indicate to the backend api where this call report came from
+      // A value of test indicates that it did not come the production environment
       const viaParameter = window.location.host === "5calls.org" ? 'web' : 'test';
+      
       const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })
       http.post(appURL+'/report', { body: body, headers: {"Content-Type": "application/x-www-form-urlencoded"} }, () => {
         // don’t really care about the result

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -425,7 +425,8 @@ app.model({
 
       send('setUserStats', data, done);
 
-      const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid })
+      const viaParameter = debug ? 'test' : 'web';
+      const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })
       http.post(appURL+'/report', { body: body, headers: {"Content-Type": "application/x-www-form-urlencoded"} }, () => {
         // don’t really care about the result
       })

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -424,8 +424,8 @@ app.model({
       }
 
       send('setUserStats', data, done);
-
-      const viaParameter = debug ? 'test' : 'web';
+      
+      const viaParameter = window.location.host === "5calls.org" ? 'web' : 'test';
       const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })
       http.post(appURL+'/report', { body: body, headers: {"Content-Type": "application/x-www-form-urlencoded"} }, () => {
         // don’t really care about the result

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -426,7 +426,7 @@ app.model({
       send('setUserStats', data, done);
       
       // This parameter will indicate to the backend api where this call report came from
-      // A value of test indicates that it did not come the production environment
+      // A value of test indicates that it did not come from the production environment
       const viaParameter = window.location.host === "5calls.org" ? 'web' : 'test';
       
       const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -427,7 +427,7 @@ app.model({
       
       // This parameter will indicate to the backend api where this call report came from
       // A value of test indicates that it did not come from the production environment
-      const viaParameter = window.location.host === "5calls.org" ? 'web' : 'test';
+      const viaParameter = window.location.host === '5calls.org' ? 'web' : 'test';
       
       const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })
       http.post(appURL+'/report', { body: body, headers: {"Content-Type": "application/x-www-form-urlencoded"} }, () => {


### PR DESCRIPTION
Sends the text "web" for a call report post originating from the "5calls.org" website and the text "test" for a call report post originating from anywhere else.