### PR TITLE
Allow the development server to respond to client side defined routes

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ var gulp = require('gulp')
   , connect_logger = require('connect-logger')
   , spawn = require('child_process').spawn
   , mocha = require('gulp-mocha')
+  , path = require('path')
   ;
 
 var SRC = {
@@ -41,9 +42,22 @@ gulp.task('html:watch', function() {
 });
 
 gulp.task('html:serve', function (cb) {
+
+  function alwaysServeIndex(req, res, next) {
+  
+    // Allow the development server to respond to URLs defined in the front end application.
+    // Assume that any URL without a file extension can be handled by the client side code
+    // and serve index.html (instead of 404).
+  
+    if(!(path.extname(req.url))) {
+      req.url = "/";
+    }
+    next();
+  }  
+
   var server = new http_server.HttpServer({
     root: 'app/static',
-    before: [connect_logger()]
+    before: [connect_logger(), alwaysServeIndex]
   });
   server.listen(8000, function () {
     util.log('HTTP server started on port 8000');


### PR DESCRIPTION
Responds to any URL that does not have an extension with index.html. This is an attempt to loosely mimic the behavior of the production server after the recent removal of hash URLs.