### PR TITLE
Attempt to fix problem running unit tests on Windows

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,6 +144,7 @@ function runKarmaTests ({singleRun, configFile} = {}) {
     // process instead. See:
     // https://github.com/karma-runner/karma/issues/1693
     // https://github.com/karma-runner/karma/issues/1035
+    
     const karma = spawn(path.join(__dirname, 'node_modules', '.bin', 'karma'), karmaArguments, {
       shell: true,
       cwd: __dirname,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,7 +144,8 @@ function runKarmaTests ({singleRun, configFile} = {}) {
     // process instead. See:
     // https://github.com/karma-runner/karma/issues/1693
     // https://github.com/karma-runner/karma/issues/1035
-    const karma = spawn('./node_modules/.bin/karma', karmaArguments, {
+    const karma = spawn(path.join(__dirname, 'node_modules', '.bin', 'karma'), karmaArguments, {
+      shell: true,
       cwd: __dirname,
       stdio: 'inherit'
     });


### PR DESCRIPTION
- use path.join() to generate cross platform path to karma binary
- add shell:true option to help spawn command find the .cmd version of karma on windows