### PR TITLE
Clearer Location Form

### DIFF
--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -36,7 +36,7 @@ module.exports = (state, prev, send) => {
         !state.validatingLocation &&
         (state.address ||
          state.cachedCity)) {
-          return html`<p><button onclick=${enterLocation}>Change location</button></p>`
+      return html`<p><button onclick=${enterLocation}>Change location</button></p>`;
     } else {
       const className = (state.fetchingLocation) ? 'hidden' : '';
       return html`<p>

--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -17,7 +17,7 @@ module.exports = (state, prev, send) => {
     if (state.fetchingLocation || state.validatingLocation) {
       return html`<p id="locationMessage" class="loadingAnimation">Getting your location</p>`;
     } else if (state.askingLocation) {
-      return html`<p id="locationMessage">Choose a location</p>`;
+      return html`<p id="locationMessage">Enter your location</p>`;
     } else if (state.invalidAddress) {
       return html`<p id="locationMessage" role="alert">That address is invalid, please try again</p>`;
     } else if (state.address) {
@@ -25,7 +25,7 @@ module.exports = (state, prev, send) => {
     } else if (state.cachedCity) {
       return html`<p id="locationMessage">Your location: <span>${state.cachedCity}</span> ${debugText(state.debug)}</p>`;
     } else {
-      return html`<p id="locationMessage">Choose a location</p>`;
+      return html`<p id="locationMessage">Enter your location</p>`;
     }
   }
 

--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -1,7 +1,8 @@
 const html = require('choo/html');
 
 module.exports = (state, prev, send) => {
-  if (state.askingLocation && !state.fetchingLocation) {
+  if ((state.askingLocation && !state.fetchingLocation) ||
+      state.invalidAddress) {
     send('focusLocation');
   }
 
@@ -14,17 +15,17 @@ module.exports = (state, prev, send) => {
 
   function pretext(state) {
     if (state.fetchingLocation || state.validatingLocation) {
-      return html`<p class="locationMessage loadingAnimation">Getting your location</p>`;
+      return html`<p id="locationMessage" class="loadingAnimation">Getting your location</p>`;
     } else if (state.askingLocation) {
-      return html`<p class="locationMessage">Choose a location</p>`;
+      return html`<p id="locationMessage">Choose a location</p>`;
     } else if (state.invalidAddress) {
-      return html`<p class="locationMessage">That address is invalid, please try again</p>`;
+      return html`<p id="locationMessage" role="alert">That address is invalid, please try again</p>`;
     } else if (state.address) {
-      return html`<p class="locationMessage">Your location: <span>${state.address}</span></p>`;
+      return html`<p id="locationMessage">Your location: <span>${state.address}</span></p>`;
     } else if (state.cachedCity) {
-      return html`<p class="locationMessage">Your location: <span>${state.cachedCity}</span> ${debugText(state.debug)}</p>`;
+      return html`<p id="locationMessage">Your location: <span>${state.cachedCity}</span> ${debugText(state.debug)}</p>`;
     } else {
-      return html`<p class="locationMessage">Choose a location</p>`;
+      return html`<p id="locationMessage">Choose a location</p>`;
     }
   }
 
@@ -38,7 +39,14 @@ module.exports = (state, prev, send) => {
           return html`<p><button onclick=${enterLocation}>Change location</button></p>`
     } else {
       const className = (state.fetchingLocation) ? 'hidden' : '';
-      return html`<p><form onsubmit=${submitAddress} class=${className}><input type="text" autofocus="true" id="address" name="address" placeholder="Enter an address or zip code" /> <button>Go</button></form></p>`;
+      return html`<p>
+      <form onsubmit=${submitAddress} class=${className}>
+        <input type="text" autofocus="true" id="address" name="address" \
+          aria-labelledby="locationMessage" aria-invalid=${state.invalidAddress} \
+          disabled=${state.validatingLocation}
+          placeholder="Enter an address or zip code" />
+        <button>Go</button>
+      </form></p>`;
     }
   }
 

--- a/static/js/components/issuesLocation.js
+++ b/static/js/components/issuesLocation.js
@@ -8,29 +8,38 @@ module.exports = (state, prev, send) => {
   return html`
     <div class="issues__location">
     ${pretext(state)}
-    ${addressForm(state)}
+    ${addressFormOrButton(state)}
     </div>
   `;
 
   function pretext(state) {
-    if (state.fetchingLocation) {
-      return html`<p class="loadingAnimation">Getting your location</p>`;
+    if (state.fetchingLocation || state.validatingLocation) {
+      return html`<p class="locationMessage loadingAnimation">Getting your location</p>`;
     } else if (state.askingLocation) {
-      return html``;
+      return html`<p class="locationMessage">Choose a location</p>`;
     } else if (state.invalidAddress) {
-      return html`<p><button class="subtle-button" onclick=${enterLocation}>That address is invalid, please try again</button></p>`;
+      return html`<p class="locationMessage">That address is invalid, please try again</p>`;
     } else if (state.address) {
-      return html`<p>for <button class="subtle-button" onclick=${enterLocation}>${state.address}</button></p>`;
+      return html`<p class="locationMessage">Your location: <span>${state.address}</span></p>`;
     } else if (state.cachedCity) {
-      return html`<p>for <button class="subtle-button" onclick=${enterLocation}> ${state.cachedCity}</button> ${debugText(state.debug)}</p>`;
+      return html`<p class="locationMessage">Your location: <span>${state.cachedCity}</span> ${debugText(state.debug)}</p>`;
     } else {
-      return html`<p><button class="subtle-button" onclick=${enterLocation}>Choose a location</button></p>`;
+      return html`<p class="locationMessage">Choose a location</p>`;
     }
   }
 
-  function addressForm(state) {
-    const className = (state.askingLocation && !state.fetchingLocation) ? '' : 'hidden';
-    return html`<p><form onsubmit=${submitAddress} class=${className}><input type="text" autofocus="true" id="address" name="address" placeholder="Enter an address or zip code" /> <button>Go</button></form></p>`;
+  function addressFormOrButton(state) {
+    if (!state.askingLocation &&
+        !state.fetchingLocation &&
+        !state.invalidAddress &&
+        !state.validatingLocation &&
+        (state.address ||
+         state.cachedCity)) {
+          return html`<p><button onclick=${enterLocation}>Change location</button></p>`
+    } else {
+      const className = (state.fetchingLocation) ? 'hidden' : '';
+      return html`<p><form onsubmit=${submitAddress} class=${className}><input type="text" autofocus="true" id="address" name="address" placeholder="Enter an address or zip code" /> <button>Go</button></form></p>`;
+    }
   }
 
   function debugText(debug) {

--- a/static/js/components/issuesLocation_test.js
+++ b/static/js/components/issuesLocation_test.js
@@ -7,7 +7,8 @@ describe('issuesLocation component', () => {
     const testCases = [
       {state: {askingLocation: true, fetchingLocation: false}, shouldSend: true},
       {state: {askingLocation: true, fetchingLocation: true}, shouldSend: false},
-      {state: {askingLocation: false, fetchingLocation: false}, shouldSend: false}
+      {state: {askingLocation: false, fetchingLocation: false}, shouldSend: false},
+      {state: {askingLocation: false, fetchingLocation: false, invalidAddress: true}, shouldSend: true}
     ];
     testCases.forEach(({state, shouldSend}) => {
       it('should' + (shouldSend ? '' : ' not') + ' send "focusLocation" when ' +
@@ -46,7 +47,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(expected)
     });
     it('should tell user when validating location and still show form', () => {
@@ -57,7 +58,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(expected)
     });
     it('should prompt user for another address when address is invalid', () => {
@@ -68,7 +69,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(expected)
     });
     it('should reflect the current address if available', () => {
@@ -80,7 +81,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(address)
     });
     it('should reflect the current cached city if available', () => {
@@ -92,7 +93,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(cachedCity)
     });
     it('should prompt for an address if nothing else', () => {
@@ -102,7 +103,7 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('.locationMessage')
+      let messageElement = result.querySelector('#locationMessage')
       expect(messageElement.innerText).to.contain(expected)
     });
   });

--- a/static/js/components/issuesLocation_test.js
+++ b/static/js/components/issuesLocation_test.js
@@ -25,13 +25,6 @@ describe('issuesLocation component', () => {
     });
   });
   describe('html content', () => {
-    /*
-    it('should always include the addressForm', () => {
-      let result = issuesLocation({}, null, () => {});
-      let formElement = result.querySelector('form');
-      expect(formElement).to.be.defined;
-    });
-    */
     it('should tell user when fetching location and hide form', () => {
       const expected = 'Getting your location';
       const state = {fetchingLocation: true};
@@ -44,33 +37,27 @@ describe('issuesLocation component', () => {
       const state = {fetchingLocation: false, askingLocation:true};
       const expected = "Choose a location";
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(expected);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(expected);
     });
     it('should tell user when validating location and still show form', () => {
       const expected = 'Getting your location';
       const state = {fetchingLocation: false, askingLocation:false,
         validatingLocation: true};
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(expected);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(expected);
     });
     it('should prompt user for another address when address is invalid', () => {
       const expected = 'address is invalid';
       const state = {fetchingLocation: false, askingLocation:false,
         invalidAddress: true};
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(expected);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(expected);
     });
     it('should reflect the current address if available', () => {
       const address = '123 Main St. 12345';
@@ -78,11 +65,9 @@ describe('issuesLocation component', () => {
         validatingLocation: false, invalidAddress: false,
         address};
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(address);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(address);
     });
     it('should reflect the current cached city if available', () => {
       const cachedCity = 'Munroe';
@@ -90,21 +75,17 @@ describe('issuesLocation component', () => {
         validatingLocation: false,
         invalidAddress: false, cachedCity};
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(cachedCity);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(cachedCity);
     });
     it('should prompt for an address if nothing else', () => {
       const expected = 'Choose a location';
       const state = {};
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(2);
+      expect(result.innerText).to.contain(expected);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage');
-      expect(messageElement.innerText).to.contain(expected);
     });
   });
 });

--- a/static/js/components/issuesLocation_test.js
+++ b/static/js/components/issuesLocation_test.js
@@ -42,59 +42,59 @@ describe('issuesLocation component', () => {
     });
     it('should prompt user for address when askingLocation', () => {
       const state = {fetchingLocation: false, askingLocation:true};
-      const expected = "Choose a location"
+      const expected = "Choose a location";
       let result = issuesLocation(state, null, () => {});
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(expected)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(expected);
     });
     it('should tell user when validating location and still show form', () => {
       const expected = 'Getting your location';
       const state = {fetchingLocation: false, askingLocation:false,
-        validatingLocation: true}
+        validatingLocation: true};
       let result = issuesLocation(state, null, () => {});
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(expected)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(expected);
     });
     it('should prompt user for another address when address is invalid', () => {
       const expected = 'address is invalid';
       const state = {fetchingLocation: false, askingLocation:false,
-                     invalidAddress: true};
+        invalidAddress: true};
       let result = issuesLocation(state, null, () => {});
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(expected)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(expected);
     });
     it('should reflect the current address if available', () => {
       const address = '123 Main St. 12345';
       const state = {fetchingLocation: false, askingLocation:false,
-                     validatingLocation: false, invalidAddress: false,
-                     address};
+        validatingLocation: false, invalidAddress: false,
+        address};
       let result = issuesLocation(state, null, () => {});
       expect(result.querySelectorAll("p")).to.have.length(2);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(address)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(address);
     });
     it('should reflect the current cached city if available', () => {
       const cachedCity = 'Munroe';
       const state = {fetchingLocation: false, askingLocation:false,
-                     validatingLocation: false,
-                     invalidAddress: false, cachedCity};
+        validatingLocation: false,
+        invalidAddress: false, cachedCity};
       let result = issuesLocation(state, null, () => {});
       expect(result.querySelectorAll("p")).to.have.length(2);
       let buttonElement = result.querySelector('button');
       expect(buttonElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(cachedCity)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(cachedCity);
     });
     it('should prompt for an address if nothing else', () => {
       const expected = 'Choose a location';
@@ -103,8 +103,8 @@ describe('issuesLocation component', () => {
       expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
-      let messageElement = result.querySelector('#locationMessage')
-      expect(messageElement.innerText).to.contain(expected)
+      let messageElement = result.querySelector('#locationMessage');
+      expect(messageElement.innerText).to.contain(expected);
     });
   });
 });

--- a/static/js/components/issuesLocation_test.js
+++ b/static/js/components/issuesLocation_test.js
@@ -35,7 +35,7 @@ describe('issuesLocation component', () => {
     });
     it('should prompt user for address when askingLocation', () => {
       const state = {fetchingLocation: false, askingLocation:true};
-      const expected = "Choose a location";
+      const expected = "Enter your location";
       let result = issuesLocation(state, null, () => {});
       expect(result.innerText).to.contain(expected);
       let formElement = result.querySelector('form');
@@ -80,7 +80,7 @@ describe('issuesLocation component', () => {
       expect(buttonElement.classList.contains('hidden')).to.be.false;
     });
     it('should prompt for an address if nothing else', () => {
-      const expected = 'Choose a location';
+      const expected = 'Enter your location';
       const state = {};
       let result = issuesLocation(state, null, () => {});
       expect(result.innerText).to.contain(expected);

--- a/static/js/components/issuesLocation_test.js
+++ b/static/js/components/issuesLocation_test.js
@@ -24,12 +24,14 @@ describe('issuesLocation component', () => {
     });
   });
   describe('html content', () => {
+    /*
     it('should always include the addressForm', () => {
       let result = issuesLocation({}, null, () => {});
       let formElement = result.querySelector('form');
       expect(formElement).to.be.defined;
     });
-    it('should tell user when fetching location and hide addressForm', () => {
+    */
+    it('should tell user when fetching location and hide form', () => {
       const expected = 'Getting your location';
       const state = {fetchingLocation: true};
       let result = issuesLocation(state, null, () => {});
@@ -39,45 +41,69 @@ describe('issuesLocation component', () => {
     });
     it('should prompt user for address when askingLocation', () => {
       const state = {fetchingLocation: false, askingLocation:true};
+      const expected = "Choose a location"
       let result = issuesLocation(state, null, () => {});
-      expect(result.querySelectorAll("p")).to.have.length(1);
+      expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
       expect(formElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(expected)
     });
-    it('should tell the user about an invalid address', () => {
+    it('should tell user when validating location and still show form', () => {
+      const expected = 'Getting your location';
+      const state = {fetchingLocation: false, askingLocation:false,
+        validatingLocation: true}
+      let result = issuesLocation(state, null, () => {});
+      expect(result.querySelectorAll("p")).to.have.length(2);
+      let formElement = result.querySelector('form');
+      expect(formElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(expected)
+    });
+    it('should prompt user for another address when address is invalid', () => {
       const expected = 'address is invalid';
       const state = {fetchingLocation: false, askingLocation:false,
                      invalidAddress: true};
       let result = issuesLocation(state, null, () => {});
-      expect(result.innerText).to.contain(expected);
+      expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
-      expect(formElement.classList.contains('hidden')).to.be.true;
+      expect(formElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(expected)
     });
     it('should reflect the current address if available', () => {
       const address = '123 Main St. 12345';
       const state = {fetchingLocation: false, askingLocation:false,
-                     invalidAddress: false, address};
+                     validatingLocation: false, invalidAddress: false,
+                     address};
       let result = issuesLocation(state, null, () => {});
-      expect(result.innerText).to.contain(address);
-      let formElement = result.querySelector('form');
-      expect(formElement.classList.contains('hidden')).to.be.true;
+      expect(result.querySelectorAll("p")).to.have.length(2);
+      let buttonElement = result.querySelector('button');
+      expect(buttonElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(address)
     });
     it('should reflect the current cached city if available', () => {
       const cachedCity = 'Munroe';
       const state = {fetchingLocation: false, askingLocation:false,
+                     validatingLocation: false,
                      invalidAddress: false, cachedCity};
       let result = issuesLocation(state, null, () => {});
-      expect(result.innerText).to.contain(cachedCity);
-      let formElement = result.querySelector('form');
-      expect(formElement.classList.contains('hidden')).to.be.true;
+      expect(result.querySelectorAll("p")).to.have.length(2);
+      let buttonElement = result.querySelector('button');
+      expect(buttonElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(cachedCity)
     });
     it('should prompt for an address if nothing else', () => {
       const expected = 'Choose a location';
       const state = {};
       let result = issuesLocation(state, null, () => {});
-      expect(result.innerText).to.contain(expected);
+      expect(result.querySelectorAll("p")).to.have.length(2);
       let formElement = result.querySelector('form');
-      expect(formElement.classList.contains('hidden')).to.be.true;
+      expect(formElement.classList.contains('hidden')).to.be.false;
+      let messageElement = result.querySelector('.locationMessage')
+      expect(messageElement.innerText).to.contain(expected)
     });
   });
 });

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -369,8 +369,10 @@ app.model({
     // in the issuesLocation component.
     focusLocation: (state, data, send, done) => {
       let addressElement = document.querySelector('#address')
-      scrollIntoView(addressElement);
       addressElement.focus();
+      //feedback test above form should also be visible
+      let addressLabel = document.querySelector("#locationMessage")
+      scrollIntoView(addressLabel)
       // Clear previous address to show placeholder text to
       // reinforce entering a new one.
       addressElement.value = "";

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -120,6 +120,7 @@ app.model({
     // completeIssue: false,
     askingLocation: false,
     fetchingLocation: cachedFetchingLocation,
+    validatingLocation: false,
     locationFetchType: cachedLocationFetchType,
     contactIndices: {},
     completedIssues: completedIssues,
@@ -136,6 +137,7 @@ app.model({
         activeIssues: response.issues,
         splitDistrict: response.splitDistrict,
         invalidAddress: response.invalidAddress,
+        validatingLocation: false
       }
     },
     receiveInactiveIssues: (state, data) => {
@@ -193,7 +195,7 @@ app.model({
     setAddress: (state, address) => {
       store.replace("org.5calls.location", 0, address, () => {});
 
-      return { address: address, askingLocation: false }
+      return { address: address, askingLocation: false, validatingLocation: true }
     },
     setGeolocation: (state, data) => {
       store.replace("org.5calls.geolocation", 0, data, () => {});
@@ -419,11 +421,11 @@ app.model({
       }
 
       send('setUserStats', data, done);
-      
+
       // This parameter will indicate to the backend api where this call report came from
       // A value of test indicates that it did not come from the production environment
       const viaParameter = window.location.host === '5calls.org' ? 'web' : 'test';
-      
+
       const body = queryString.stringify({ location: state.zip, result: data.result, contactid: data.contactid, issueid: data.issueid, via: viaParameter })
       http.post(appURL+'/report', { body: body, headers: {"Content-Type": "application/x-www-form-urlencoded"} }, () => {
         // don’t really care about the result

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -370,7 +370,7 @@ app.model({
     focusLocation: (state, data, send, done) => {
       let addressElement = document.querySelector('#address')
       addressElement.focus();
-      //feedback test above form should also be visible
+      //feedback message above form should also be visible
       let addressLabel = document.querySelector("#locationMessage");
       scrollIntoView(addressLabel);
       // Clear previous address to show placeholder text to

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -371,8 +371,8 @@ app.model({
       let addressElement = document.querySelector('#address')
       addressElement.focus();
       //feedback test above form should also be visible
-      let addressLabel = document.querySelector("#locationMessage")
-      scrollIntoView(addressLabel)
+      let addressLabel = document.querySelector("#locationMessage");
+      scrollIntoView(addressLabel);
       // Clear previous address to show placeholder text to
       // reinforce entering a new one.
       addressElement.value = "";

--- a/static/scss/_issues.scss
+++ b/static/scss/_issues.scss
@@ -36,12 +36,15 @@
   }
 
   &__location {
-    color: $gray;
+    color: $blue;
 
     p {
       margin: 0;
       font-size: $font-small;
-      padding: 6px 6px 12px;
+      padding: 6px 6px 6px;
+      &.loadingAnimation {
+        color: $gray;
+      }
     }
 
     input {
@@ -50,6 +53,10 @@
 
     a {
       text-decoration: underline;
+    }
+
+    span {
+      font-weight: bold;
     }
   }
 


### PR DESCRIPTION
This PR addresses issue #262.

* If you already have a valid location, show "Change Location" button.
* If you click the "Change Location" button, or your location is invalid or missing, or you're prompted for your location because you're in a split district, show the form instead.
* While waiting for a response from the `/issues/` endpoint, it displays the same "Getting your location" text as when it's getting location info from the browser. I had to add a "validatingLocation" flag to the state to make that work.
* Also added a couple ARIA attributes.