### PR TITLE
Adds dynamic scripts

### DIFF
--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -2,7 +2,7 @@ const html = require('choo/html');
 const t = require('../utils/translation');
 
 const find = require('lodash/find');
-const scriptLine = require('./scriptLine.js');
+const scriptFormat = require('./scriptFormat.js');
 
 module.exports = (state, prev, send) => {
   const issue = find(state.issues, ['id', state.location.params.issueid]);
@@ -13,7 +13,7 @@ module.exports = (state, prev, send) => {
     return html`
       <div class="call__script">
         <h3 class="call__script__header">${t("script.yourScript")}</h3>
-        <div class="call__script__body">${issue.script.split('\n').map((line) => scriptLine(line, state, prev, send))}</div>
+        ${scriptFormat(issue, state, prev, send)}
       </div>`;      
   } else {
     return html``;

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -7,10 +7,12 @@ module.exports = (issue, state) => {
 
   // Replacement regexes, ideally standardize copy to avoid complex regexs
   const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
+  const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
   function format() {
     let script = issue.script;
 
+    let location = state.cachedCity;
     let title = '';
     if (currentContact.area == 'House') {
       title = 'Rep. ' + currentContact.name.split(' ').pop();
@@ -18,8 +20,11 @@ module.exports = (issue, state) => {
       title = 'Senator ' + currentContact.name.split(' ').pop();
     }
 
-    if (title.length > 0) {
+    if (title) {
       script = script.replace(titleReg, title);
+    }
+    if (location) {
+      script = script.replace(locationReg, location);
     }
 
     return script.split('\n').map((line) => scriptLine(line));

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -15,9 +15,9 @@ module.exports = (issue, state) => {
     let location = state.cachedCity;
     let title = '';
     if (currentContact.area == 'House') {
-      title = 'Rep. ' + currentContact.name.split(' ').pop();
+      title = 'Rep. ' + currentContact.name;
     } else if (currentContact.area == 'Senate') {
-      title = 'Senator ' + currentContact.name.split(' ').pop();
+      title = 'Senator ' + currentContact.name;
     }
 
     if (title) {
@@ -35,4 +35,4 @@ module.exports = (issue, state) => {
       ${format()}
     </div>
   `;
-}
+};

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -1,0 +1,33 @@
+const html = require('choo/html');
+const scriptLine = require('./scriptLine.js');
+
+module.exports = (issue, state) => {
+  const currentIndex = state.contactIndices[issue.id];
+  const currentContact = issue.contacts[currentIndex];
+
+  // Replacement regexes, ideally standardize copy to avoid complex regexs
+  const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
+
+  function format() {
+    let script = issue.script;
+
+    let title = '';
+    if (currentContact.area == 'House') {
+      title = 'Rep. ' + currentContact.name.split(' ').pop();
+    } else if (currentContact.area == 'Senate') {
+      title = 'Senator ' + currentContact.name.split(' ').pop();
+    }
+
+    if (title.length > 0) {
+      script = script.replace(titleReg, title);
+    }
+
+    return script.split('\n').map((line) => scriptLine(line));
+  }
+
+  return html`
+    <div class="call__script__body">
+      ${format()}
+    </div>
+  `;
+}

--- a/static/js/components/scriptFormat_test.js
+++ b/static/js/components/scriptFormat_test.js
@@ -1,0 +1,82 @@
+const scriptFormat = require('./scriptFormat.js');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('scriptFormatter', () => {
+  let id = 1;
+  let location = {params: {issueid: 1}};
+  let contactIndices = {};
+  contactIndices[id] = 0;
+  let stateDefault = {
+    location,
+    contactIndices
+  };
+  let issueDefault = {
+    id: id,
+    name: 'Call Bozo Blowhart',
+    reason: 'Bozo is bad',
+  };
+
+  describe('title replacement', () => {
+    it('should replace with senator title', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'Senate',
+        party: 'Dem'
+      };
+      let script = 'Please vote against [REP/SEN NAME]. It will be bad if you dont vote against [Senator/Rep Name].';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain('Please vote against Senator Blowhart. It will be bad if you dont vote against Senator Blowhart.');
+    });
+    it('should replace with rep title', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'House',
+        party: 'Dem'
+      };
+      let script = 'Please vote against [REP/SEN NAME]. It will be bad if you dont vote against [Senator/Rep Name].';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain('Please vote against Rep. Blowhart. It will be bad if you dont vote against Rep. Blowhart.');
+    });
+    it('should not replace title when not house or senate', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: '',
+        party: 'Dem'
+      };
+      let script = 'Please vote against REP/SEN NAME. It will be bad if you dont vote against [Senator Name].';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain(script);
+    }); 
+    it('should not replace when no valid replacement string', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'Senates',
+        party: 'Dem'
+      };
+      let script = 'Please vote against [REP/SEN NAME]. It will be bad if you dont vote against [Senator/Rep Name].';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain(script);
+    }); 
+  });
+});

--- a/static/js/components/scriptFormat_test.js
+++ b/static/js/components/scriptFormat_test.js
@@ -79,4 +79,54 @@ describe('scriptFormatter', () => {
       expect(result.textContent).to.contain(script);
     }); 
   });
+  describe('location replacement', () => {
+    it('should replace with location', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'Senate',
+        party: 'Dem'
+      };
+      let script = 'I am from [CITY, ZIP]. I love [City,State].';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      state['cachedCity'] = 'Oakland';
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain('I am from Oakland. I love Oakland.');
+    });
+    it('should not replace with invalid location replacement string', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'Senate',
+        party: 'Dem'
+      };
+      let script = 'I am from [CITY,ZIP. I love State.';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      state['cachedCity'] = 'Oakland';
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain(script);
+    });    
+    it('should not replace if no cached city', () => {
+      let contact = {
+        name: 'Bozo B. Blowhart',
+        area: 'Senate',
+        party: 'Dem'
+      };
+      let script = 'I am from [CITY,ZIP. I love State.';
+      let issue = issueDefault;
+      let state = stateDefault;
+      issue['contacts'] = [contact];
+      issue['script'] = script;
+      state['issues'] = issue;
+      state['cachedCity'] = '';
+      let result = scriptFormat(issue, state);
+      expect(result.textContent).to.contain(script);
+    });
+  });
 });

--- a/static/js/components/scriptFormat_test.js
+++ b/static/js/components/scriptFormat_test.js
@@ -31,7 +31,7 @@ describe('scriptFormatter', () => {
       issue['script'] = script;
       state['issues'] = issue;
       let result = scriptFormat(issue, state);
-      expect(result.textContent).to.contain('Please vote against Senator Blowhart. It will be bad if you dont vote against Senator Blowhart.');
+      expect(result.textContent).to.contain('Please vote against Senator Bozo B. Blowhart. It will be bad if you dont vote against Senator Bozo B. Blowhart.');
     });
     it('should replace with rep title', () => {
       let contact = {
@@ -46,7 +46,7 @@ describe('scriptFormatter', () => {
       issue['script'] = script;
       state['issues'] = issue;
       let result = scriptFormat(issue, state);
-      expect(result.textContent).to.contain('Please vote against Rep. Blowhart. It will be bad if you dont vote against Rep. Blowhart.');
+      expect(result.textContent).to.contain('Please vote against Rep. Bozo B. Blowhart. It will be bad if you dont vote against Rep. Bozo B. Blowhart.');
     });
     it('should not replace title when not house or senate', () => {
       let contact = {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -212,7 +212,7 @@ app.model({
     },
     setCachedCity: (state, data) => {
       const response = JSON.parse(data);
-      if (response.normalizedLocation && state.cachedCity == '') {
+      if (response.normalizedLocation) {
         store.replace("org.5calls.geolocation_city", 0, response.normalizedLocation, () => {});
         return { cachedCity: response.normalizedLocation };
       } else {


### PR DESCRIPTION
## Summary
Adds new component `scriptFormat.js` to replace specified script placeholders. It uses regex to replace the script, and currently will replace location and representative titles. The PR also removes a check in `setCachedCity()` so that `state.cachedCity` is updated more frequently. 

`[CITY, STATE]` => Urbana
`[REP/SEN NAME]` => Senator Duckworth
`[REP/SEN NAME]` => Rep. Davis

## Tests
Manual testing and unit tests were added.
Before:
![Before](https://cloud.githubusercontent.com/assets/5424713/25267950/80675fcc-263c-11e7-9835-e363a337e63b.png)
After:
![After](https://cloud.githubusercontent.com/assets/5424713/25267951/806a4d9a-263c-11e7-9738-86a5b95736c6.png)

## Notes
Currently only the city is provided in `response.normalizedLocation`, when ideally State or ZIP would also be useful. An option could be to modify the backend to also return State or ZIP from Google Civic API. 

For the future, other dynamic fields could be bill names like "[HR 1880 for House/S 806 for Senate]", but this would require more standardization on copy's end.