### PR TITLE
Rendering the impact link in the footer

### DIFF
--- a/static/js/components/footer.js
+++ b/static/js/components/footer.js
@@ -1,7 +1,21 @@
 const html = require('choo/html');
 const t = require('../utils/translation');
 
-module.exports = () => {
+module.exports = (state) => {
+
+  function impactLink (userStats) {
+
+    if (userStats && userStats.all) {
+      if ( userStats.all.length > 0 ) {
+        return html`
+          <a id="impact__link" href="/impact">
+            <i class="fa fa-line-chart" aria-hidden="true"></i> ${t('footer.impact')}
+          </a>`;
+      }
+    }
+
+    return null;
+  }
 
   return html`
       <footer><div class="tinyletter__form">
@@ -29,9 +43,9 @@ module.exports = () => {
         <a href="#about">
           <i class="fa fa-heart" aria-hidden="true"></i> ${t('footer.about')}
         </a>
-        <a id="impact__link" href="/impact">
-          <i class="fa fa-line-chart" aria-hidden="true"></i> ${t('footer.impact')}
-        </a>
+
+        ${impactLink(state.userStats)}
+
         <a href="https://5calls.zendesk.com/hc/en-us/sections/115000760947-FAQ">
           <i class="fa fa-question-circle" aria-hidden="true"></i> ${t('footer.faq')}
         </a>

--- a/static/js/components/footer_test.js
+++ b/static/js/components/footer_test.js
@@ -1,0 +1,28 @@
+const footer = require('./footer.js');
+const expect = require('chai').expect;
+
+describe('footer component', () => {
+
+  it('should not display impact link if user has not made any calls', () => {
+  
+    let state = {
+      userStats: { all: [] }
+    };
+    
+    let result = footer(state);
+    
+    expect(result.querySelector('#impact__link')).not.to.exist;
+  });
+
+  it('should display impact link if user has made  calls', () => {
+
+    let state = {
+      userStats: { all: [1] }
+    };
+    
+    let result = footer(state);
+    
+    expect(result.querySelector('#impact__link')).to.exist;
+  });
+  
+});


### PR DESCRIPTION
To address #293, render the impact link only if the user has stats available.

Checks whether the array `userStats.all` exists and has length.