### PR TITLE
Expand dynamic scripts

### DIFF
--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -8,7 +8,7 @@ module.exports = (state, prev, send) => {
   const issue = find(state.issues, ['id', state.location.params.issueid]);
   const currentIndex = state.contactIndices[issue.id];
   const currentContact = issue.contacts[currentIndex];
-    
+
   if (currentContact != null) {
     return html`
       <div class="call__script">

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -4,27 +4,66 @@ const scriptLine = require('./scriptLine.js');
 module.exports = (issue, state) => {
   const currentIndex = state.contactIndices[issue.id];
   const currentContact = issue.contacts[currentIndex];
+  let script = issue.script;
 
   // Replacement regexes, ideally standardize copy to avoid complex regexs
-  const titleReg = /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]/gi;
-  const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
+  // location - [CITY, ZIP], [CITY, STATE]
+  // title - [REP/SEN NAME], [SENATOR/REP NAME], [SEN/REP NAME]
+  // sen - [SEN NAME], [SENATOR NAME]
+  // rep - [REP NAME], [REP'S NAME]
+  // attgen - [Attorney General Name]
+  // bill - [Senate: S. 823; House: H.R. 1899], [House- HR 1180, Senate- S 801]
+  const reg = {
+    location: /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi,
+    title: /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]|\[SEN\/REP NAME\]/gi,
+    sen: /\[SEN NAME\]|\[SENATOR NAME\]/gi,
+    rep: /\[REP NAME\]|\[REP'S NAME\]/gi,
+    attgen: /\[ATTORNEY GENERAL NAME\]/gi,
+  }
+
+  const replace = {
+    location: state.cachedCity,
+    sen: '',
+    rep: '',
+    attgen: '',
+  }
+
+  for (let i = 0; i < issue.contacts.length; i++) {
+    let curr = issue.contacts[i];
+    if (curr.area == 'House') {
+      replace.rep = 'Rep. ' + curr.name;
+    } else if (curr.area == 'Senate') {
+      replace.sen = 'Senator ' + curr.name;
+    } else if (curr.area == 'AttorneyGeneral') {
+      replace.attgen = 'Attorney General ' + curr.name;
+    }
+  }
 
   function format() {
     let script = issue.script;
 
-    let location = state.cachedCity;
     let title = '';
     if (currentContact.area == 'House') {
-      title = 'Rep. ' + currentContact.name;
+      title = replace.rep;
     } else if (currentContact.area == 'Senate') {
-      title = 'Senator ' + currentContact.name;
+      title = replace.sen;
     }
 
     if (title) {
-      script = script.replace(titleReg, title);
+      script = script.replace(reg.title, replace.title);
+      script = script.replace
+    }
+    if (sen) {
+      script = script.replace(reg.sen, replace.sen);
+    }
+    if (rep) {
+      script = script.replace(reg.rep, replace.rep);
+    }
+    if (attgen) {
+      script = script.replace(reg.attgen, replace.attgen);
     }
     if (location) {
-      script = script.replace(locationReg, location);
+      script = script.replace(reg.location, replace.location);
     }
 
     return script.split('\n').map((line) => scriptLine(line));

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -14,6 +14,8 @@ module.exports = (issue, state) => {
   // attgen - [Attorney General Name]
   // bill1 - [Senate: S. 823; House- HR 1899]
   // bill2 - [House- H.R. 1180, Senate: S 801]
+  // committee - [IF COMMITTEE, ADD: Please pass my message along to the Chairman.]
+
   const reg = {
     location: /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi,
     title: /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]|\[SEN\/REP NAME\]/gi,
@@ -22,6 +24,7 @@ module.exports = (issue, state) => {
     attgen: /\[ATTORNEY GENERAL NAME\]/gi,
     bill1: /\[SENATE[:|-]\s?(S.?\s?\d+)[;|,]\s?HOUSE[:|-]\s?(H.?R.?\s?\d+)\]/gi,
     bill2: /\[HOUSE[:|-]\s?(H.?R.?\s?\d+)[;|,]\s?SENATE[:|-]\s?(S.?\s?\d+)\]/gi,
+    committee: /\[IF (?:CALLING )?COMMITTEE, ADD:\s?(.*?)\]/gi,
   }
 
   function format() {
@@ -48,15 +51,18 @@ module.exports = (issue, state) => {
       script = script.replace(reg.rep, replace.rep);
       script = script.replace(reg.bill1, "$2");
       script = script.replace(reg.bill2, "$1");
-    } 
-    if (replace.sen) {
+      script = script.replace(reg.committee, "");
+    } else if (replace.sen) {
       script = script.replace(reg.title, replace.sen);
       script = script.replace(reg.sen, replace.sen);
       script = script.replace(reg.bill1, "$1");
       script = script.replace(reg.bill2, "$2");
-    }
-    if (replace.attgen) {
+      script = script.replace(reg.committee, "");
+    } else if (replace.attgen) {
       script = script.replace(reg.attgen, replace.attgen);
+      script = script.replace(reg.committee, "");
+    } else {
+      script = script.replace(reg.committee, "$1");
     }
 
     return script.split('\n').map((line) => scriptLine(line));

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -12,58 +12,51 @@ module.exports = (issue, state) => {
   // sen - [SEN NAME], [SENATOR NAME]
   // rep - [REP NAME], [REP'S NAME]
   // attgen - [Attorney General Name]
-  // bill - [Senate: S. 823; House: H.R. 1899], [House- HR 1180, Senate- S 801]
+  // bill1 - [Senate: S. 823; House- HR 1899]
+  // bill2 - [House- H.R. 1180, Senate: S 801]
   const reg = {
     location: /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi,
     title: /\[REP\/SEN NAME\]|\[SENATOR\/REP NAME\]|\[SEN\/REP NAME\]/gi,
     sen: /\[SEN NAME\]|\[SENATOR NAME\]/gi,
     rep: /\[REP NAME\]|\[REP'S NAME\]/gi,
     attgen: /\[ATTORNEY GENERAL NAME\]/gi,
-  }
-
-  const replace = {
-    location: state.cachedCity,
-    sen: '',
-    rep: '',
-    attgen: '',
-  }
-
-  for (let i = 0; i < issue.contacts.length; i++) {
-    let curr = issue.contacts[i];
-    if (curr.area == 'House') {
-      replace.rep = 'Rep. ' + curr.name;
-    } else if (curr.area == 'Senate') {
-      replace.sen = 'Senator ' + curr.name;
-    } else if (curr.area == 'AttorneyGeneral') {
-      replace.attgen = 'Attorney General ' + curr.name;
-    }
+    bill1: /\[SENATE[:|-]\s?(S.?\s?\d+)[;|,]\s?HOUSE[:|-]\s?(H.?R.?\s?\d+)\]/gi,
+    bill2: /\[HOUSE[:|-]\s?(H.?R.?\s?\d+)[;|,]\s?SENATE[:|-]\s?(S.?\s?\d+)\]/gi,
   }
 
   function format() {
-    let script = issue.script;
+    let replace = {
+      location: state.cachedCity,
+      sen: '',
+      rep: '',
+      attgen: '',
+    }
 
-    let title = '';
     if (currentContact.area == 'House') {
-      title = replace.rep;
+      replace.rep = 'Rep. ' + currentContact.name;
     } else if (currentContact.area == 'Senate') {
-      title = replace.sen;
+      replace.sen = 'Senator ' + currentContact.name;
+    } else if (currentContact.area == 'AttorneyGeneral') {
+      replace.attgen = 'Attorney General ' + currentContact.name;
     }
 
-    if (title) {
-      script = script.replace(reg.title, replace.title);
-      script = script.replace
-    }
-    if (sen) {
-      script = script.replace(reg.sen, replace.sen);
-    }
-    if (rep) {
-      script = script.replace(reg.rep, replace.rep);
-    }
-    if (attgen) {
-      script = script.replace(reg.attgen, replace.attgen);
-    }
-    if (location) {
+    if (replace.location) {
       script = script.replace(reg.location, replace.location);
+    }
+    if (replace.rep) {
+      script = script.replace(reg.title, replace.rep);
+      script = script.replace(reg.rep, replace.rep);
+      script = script.replace(reg.bill1, "$2");
+      script = script.replace(reg.bill2, "$1");
+    } 
+    if (replace.sen) {
+      script = script.replace(reg.title, replace.sen);
+      script = script.replace(reg.sen, replace.sen);
+      script = script.replace(reg.bill1, "$1");
+      script = script.replace(reg.bill2, "$2");
+    }
+    if (replace.attgen) {
+      script = script.replace(reg.attgen, replace.attgen);
     }
 
     return script.split('\n').map((line) => scriptLine(line));

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -25,7 +25,7 @@ module.exports = (issue, state) => {
     bill1: /\[SENATE[:|-]\s?(S.?\s?\d+)[;|,]\s?HOUSE[:|-]\s?(H.?R.?\s?\d+)\]/gi,
     bill2: /\[HOUSE[:|-]\s?(H.?R.?\s?\d+)[;|,]\s?SENATE[:|-]\s?(S.?\s?\d+)\]/gi,
     committee: /\[IF (?:CALLING )?COMMITTEE, ADD:\s?(.*?)\]/gi,
-  }
+  };
 
   function format() {
     let replace = {
@@ -33,7 +33,7 @@ module.exports = (issue, state) => {
       sen: '',
       rep: '',
       attgen: '',
-    }
+    };
 
     if (currentContact.area == 'House') {
       replace.rep = 'Rep. ' + currentContact.name;


### PR DESCRIPTION
## Summary
Issue #310 

This PR refactors `scriptFormat.js` and adds 3 cases to dynamic scripts.
1. Senators/Reps/Attorney General names - currently only `[REP/SEN NAME]` is being targeted, this adds support for replacing `[REP NAME]`, `[SEN NAME]`, `[ATTORNEY GENERAL NAME]`.
2. Bill Names - displays only the correct bill title in clauses like `[House- H.R. 1180, Senate: S 801]`. Currently requires two regexs because copy is not standardized to easily match this case.
3. Committee - conditionally displays scripts for committees `[IF COMMITTEE, ADD: ...]`. Same idea can be extended to `[IF SENATE: ...]` and other conditional sentences. Also requires standardization in copy.

I think adding more cases will make the scripts more natural and content aware. However, standardizing copy is important in making the regexes simpler and easier to test.  Also, the number of regex replacements could potentially get quite large, but I am attempting to limit them by only applying the expressions relevant to the current contact. I am open to any suggestions on how this could be better implemented or standardized! 

## Examples
[Case 1 Before](https://cloud.githubusercontent.com/assets/5424713/26022673/74951032-3770-11e7-9192-51028912b71e.png)
[Case 2 After](https://cloud.githubusercontent.com/assets/5424713/26022674/77b421a4-3770-11e7-9bb3-4f3d7f3a7642.png)

[Case 2 & 3 Before](https://cloud.githubusercontent.com/assets/5424713/26022683/b109d5a2-3770-11e7-8530-35aa2985ce18.png)
[Case 2 & 3 After](https://cloud.githubusercontent.com/assets/5424713/26022684/b3bfa4f2-3770-11e7-99d4-e51f7715059c.png)