### PR TITLE
Added support for an issue link

### DIFF
--- a/static/js/components/issuesLink.js
+++ b/static/js/components/issuesLink.js
@@ -1,0 +1,20 @@
+const html = require('choo/html');
+
+const find = require('lodash/find');
+
+module.exports = (state) => {
+  const issue = find(state.issues, ['id', state.location.params.issueid]);
+
+  if (issue.link == undefined || issue.link.length == 0) {
+    return html``;
+  } else {
+    var linkTitle = issue.link;
+    if (issue.linkTitle != undefined && issue.linkTitle.length > 0) {
+      linkTitle = issue.linkTitle;
+    }
+
+    return html`
+      <h4 class="call__script__link"><a href="${issue.link}">${linkTitle}</a></h4>
+    `;
+  }
+};

--- a/static/js/components/issuesLink_test.js
+++ b/static/js/components/issuesLink_test.js
@@ -1,0 +1,69 @@
+const issuesLink = require('./issuesLink.js');
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('issuesLink component', () => {
+  it('should display link if present in state', () => {
+    let linkName = 'Go Here';
+    let id = 1;
+    let location = {params: {issueid: id}};
+    let issue = {
+      id: id,
+      name: 'Bozo the nominee',
+      reason: 'crazy',
+      script: 'Please vote against everything',
+      link: 'https://www.google.com',
+      linkTitle: linkName
+    };
+    let contact = {name: 'Senator Blowhart', party: 'Dem'};
+    let contactIndices = {};
+    contactIndices[id] = 0;
+    issue.contacts = [contact];
+    let issues = [issue];
+    let state = {issues, location, contactIndices, showFieldOfficeNumbers: false};
+    let result = issuesLink(state);
+    let element = result.querySelector('.call__script__link a');
+    expect(element.textContent).to.contain(linkName);
+  });
+
+  it('should display link without title if present in state', () => {
+    let linkURL = 'https://www.google.com';
+    let id = 1;
+    let location = {params: {issueid: id}};
+    let issue = {
+      id: id,
+      name: 'Bozo the nominee',
+      reason: 'crazy',
+      script: 'Please vote against everything',
+      link: linkURL
+    };
+    let contact = {name: 'Senator Blowhart', party: 'Dem'};
+    let contactIndices = {};
+    contactIndices[id] = 0;
+    issue.contacts = [contact];
+    let issues = [issue];
+    let state = {issues, location, contactIndices, showFieldOfficeNumbers: false};
+    let result = issuesLink(state);
+    let element = result.querySelector('.call__script__link a');
+    expect(element.textContent).to.contain(linkURL);
+  });
+
+  it('should not display link if not present in state', () => {
+    let id = 1;
+    let location = {params: {issueid: id}};
+    let issue = {
+      id: id,
+      name: 'Bozo the nominee',
+      reason: 'crazy',
+      script: 'Please vote against everything'
+    };
+    let contact = {name: 'Senator Blowhart', party: 'Dem'};
+    let contactIndices = {};
+    contactIndices[id] = 0;
+    issue.contacts = [contact];
+    let issues = [issue];
+    let state = {issues, location, contactIndices, showFieldOfficeNumbers: false};
+    let result = issuesLink(state);
+    expect(result).not.to.exist;
+  });
+});

--- a/static/js/components/script.js
+++ b/static/js/components/script.js
@@ -3,6 +3,7 @@ const t = require('../utils/translation');
 
 const find = require('lodash/find');
 const scriptFormat = require('./scriptFormat.js');
+const issuesLink = require('./issuesLink.js');
 
 module.exports = (state, prev, send) => {
   const issue = find(state.issues, ['id', state.location.params.issueid]);
@@ -13,8 +14,9 @@ module.exports = (state, prev, send) => {
     return html`
       <div class="call__script">
         <h3 class="call__script__header">${t("script.yourScript")}</h3>
-        ${scriptFormat(issue, state, prev, send)}
-      </div>`;      
+        ${scriptFormat(state, prev, send)}
+        ${issuesLink(state, prev, send)}
+      </div>`;
   } else {
     return html``;
   }

--- a/static/js/components/scriptFormat.js
+++ b/static/js/components/scriptFormat.js
@@ -1,7 +1,11 @@
 const html = require('choo/html');
 const scriptLine = require('./scriptLine.js');
 
-module.exports = (issue, state) => {
+const find = require('lodash/find');
+
+module.exports = (state) => {
+  const issue = find(state.issues, ['id', state.location.params.issueid]);
+
   const currentIndex = state.contactIndices[issue.id];
   const currentContact = issue.contacts[currentIndex];
 

--- a/static/js/components/scriptFormat_test.js
+++ b/static/js/components/scriptFormat_test.js
@@ -29,8 +29,8 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
-      let result = scriptFormat(issue, state);
+      state['issues'] = [issue];
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain('Please vote against Senator Bozo B. Blowhart. It will be bad if you dont vote against Senator Bozo B. Blowhart.');
     });
     it('should replace with rep title', () => {
@@ -44,8 +44,8 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
-      let result = scriptFormat(issue, state);
+      state['issues'] = [issue];
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain('Please vote against Rep. Bozo B. Blowhart. It will be bad if you dont vote against Rep. Bozo B. Blowhart.');
     });
     it('should not replace title when not house or senate', () => {
@@ -59,8 +59,8 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
-      let result = scriptFormat(issue, state);
+      state['issues'] = [issue];
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain(script);
     }); 
     it('should not replace when no valid replacement string', () => {
@@ -74,8 +74,8 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
-      let result = scriptFormat(issue, state);
+      state['issues'] = [issue];
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain(script);
     }); 
   });
@@ -91,9 +91,9 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
+      state['issues'] = [issue];
       state['cachedCity'] = 'Oakland';
-      let result = scriptFormat(issue, state);
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain('I am from Oakland. I love Oakland.');
     });
     it('should not replace with invalid location replacement string', () => {
@@ -107,9 +107,9 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
+      state['issues'] = [issue];
       state['cachedCity'] = 'Oakland';
-      let result = scriptFormat(issue, state);
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain(script);
     });    
     it('should not replace if no cached city', () => {
@@ -123,9 +123,9 @@ describe('scriptFormatter', () => {
       let state = stateDefault;
       issue['contacts'] = [contact];
       issue['script'] = script;
-      state['issues'] = issue;
+      state['issues'] = [issue];
       state['cachedCity'] = '';
-      let result = scriptFormat(issue, state);
+      let result = scriptFormat(state);
       expect(result.textContent).to.contain(script);
     });
   });

--- a/static/scss/_call.scss
+++ b/static/scss/_call.scss
@@ -88,6 +88,11 @@
   }
 
   &__script {
+    &__link {
+      font-size: 36px;
+      margin: 20px 0 10px 0;
+    }
+
     &__body {
       background-color: $gray-xlight;
       color: $gray;


### PR DESCRIPTION
Shows a link between the script and outcomes for promoting related stuff. In this case, we're doing a quick-and-easy link to airtable to collect trumpcare support in the senate.

Requires this callserve pr: https://github.com/5calls/callserve/pull/22

<img width="752" alt="screen shot 2017-06-12 at 5 32 52 pm" src="https://user-images.githubusercontent.com/49688/27061006-b2c7cea2-4f95-11e7-8f38-44f1287ca6f2.png">

Also refactored the scriptformat component to adhere to our style (i.e. don't pass issues through components, only choo-standard `state, prev, send` parameters)