### PR TITLE
moved the function receiveTownHallDataError into the reducers object

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -297,9 +297,9 @@ app.model({
         };
       }
     },
-  },
-  receiveTownHallDataError: () => {
-    return { localEvents: [] };
+    receiveTownHallDataError: () => {
+      return { localEvents: [] };
+    }
   },
   effects: {
     fetchTownHallData: (state, data, send, done) => {


### PR DESCRIPTION
Because this function was not defined on the receiver object, it was not getting invoked on line 313 where the send() function is used.