### PR TITLE
Improved group styles

### DIFF
--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -87,6 +87,7 @@ export interface UserStat {
 export interface Group {
   id: string;
   name: string;
+  subtitle: string;
   description: string;
   totalCalls: number;
   photoURL: string;

--- a/src/components/done/Done.tsx
+++ b/src/components/done/Done.tsx
@@ -32,7 +32,6 @@ export const Done: React.StatelessComponent<Props> = (props: Props) => {
 
         <CallCount
           totalCount={props.totalCount}
-          large={true}
           t={props.t}
         />
       </div>

--- a/src/components/done/__snapshots__/Done.test.tsx.snap
+++ b/src/components/done/__snapshots__/Done.test.tsx.snap
@@ -58,7 +58,6 @@ ShallowWrapper {
             </Trans>
         </p>
         <Translate(Component)
-            large={true}
             t={[Function]}
             totalCount={10000}
         />
@@ -115,7 +114,6 @@ ShallowWrapper {
                   </Trans>
             </p>
             <Translate(Component)
-                  large={true}
                   t={[Function]}
                   totalCount={10000}
             />
@@ -248,7 +246,6 @@ ShallowWrapper {
                               </Trans>
                     </p>
                     <Translate(Component)
-                              large={true}
                               t={[Function]}
                               totalCount={10000}
                     />
@@ -305,7 +302,6 @@ ShallowWrapper {
                               </Trans>
                     </p>
                     <Translate(Component)
-                              large={true}
                               t={[Function]}
                               totalCount={10000}
                     />

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
+import i18n from '../../services/i18n';
 import { LayoutContainer } from '../layout';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import * as ReactMarkdown from 'react-markdown';
 
 import { Group, Issue } from '../../common/model';
-import { formatNumber } from '../shared/utils';
+// import { formatNumber } from '../shared/utils';
 import { getGroup } from '../../services/apiServices';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
+import { CallCount } from '../shared';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
@@ -109,14 +111,8 @@ class GroupPage extends React.Component<Props, State> {
           return <span/>;
         }
 
-        // const pctDone = (group.totalCalls / 1000) * 100;
-        // const pctStyle = {width: `${pctDone}%`};    
-
-        const introStyle = {
-          backgroundColor: '#ddd',
-          borderRadius: '6px',
-          padding: '10px 10px 1px 10px',
-        };
+        // test indivisible image "https://scontent-sjc2-1.xx.fbcdn.net/v/t1.0-1/p480x480/17361893_1705336226148921_129555445851392992_n.jpg?oh=8ff406f4c2c63ca8ae7ab712c78f8ef7&oe=5AABD91D"
+        const groupImage = group.photoURL ? group.photoURL : "/img/5calls-stars.png";
 
         return (
           <LayoutContainer 
@@ -125,15 +121,19 @@ class GroupPage extends React.Component<Props, State> {
             issueId={this.props.match.params.issueid}
           >
             <div className="page__group">
-            {group.photoURL !== '' ?
-             <div className="page__group__image"><img alt={group.name} src={group.photoURL} /></div>
-             :
-             <span/>
-            }
-              <h2 className="page__title">{group.name}</h2>
-              <h3>Together we've made {formatNumber(group.totalCalls)} calls!</h3>
+              <div className="page__header">
+                <div className="page__header__image"><img alt={group.name} src={groupImage}/></div>
+                <h1 className="page__title">{group.name}</h1>
+                <h2 className="page__subtitle">Y'all better make some calls for this team</h2>
+              </div>
+              <CallCount
+                totalCount={group.totalCalls}
+                minimal={true}
+                t={i18n.t}
+              />
+              {/* yes, this is terrible */}
               { (group.id === 'danicaroem') ?
-              <blockquote style={introStyle}>
+              <blockquote>
                 {/*tslint:disable-next-line:max-line-length*/}
                 <p>Welcome to the phone bank for Danica Roem, candidate for Virginia’s House of Delegates for District 13!</p>
                 {/*tslint:disable-next-line:max-line-length*/}

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -111,8 +111,7 @@ class GroupPage extends React.Component<Props, State> {
           return <span/>;
         }
 
-        // test indivisible image "https://scontent-sjc2-1.xx.fbcdn.net/v/t1.0-1/p480x480/17361893_1705336226148921_129555445851392992_n.jpg?oh=8ff406f4c2c63ca8ae7ab712c78f8ef7&oe=5AABD91D"
-        const groupImage = group.photoURL ? group.photoURL : "/img/5calls-stars.png";
+        const groupImage = group.photoURL ? group.photoURL : '/img/5calls-stars.png';
 
         return (
           <LayoutContainer 
@@ -144,16 +143,7 @@ class GroupPage extends React.Component<Props, State> {
                 <p>If you’ve never made voter calls before, that’s perfectly ok! <Link to="/phonebanks">Please head over here</Link> for tips on phone banking and a great video that will make you feel ready!</p>
               </blockquote>
               : <span />}
-              {/* <div className="progress">
-                <span style={pctStyle} className="progress__total">
-                    {formatNumber(group.totalCalls)} Calls
-                </span>
-              </div> */}
               <ReactMarkdown source={group.description}/>
-              {/* <p>{groupId === group.id ? 
-                  `You're contributing to the call total for this team!` : 
-                  `Join this group to start making your calls count towards this team's total.`
-              }</p> */}
             </div>
           </LayoutContainer>
         );

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -123,7 +123,7 @@ class GroupPage extends React.Component<Props, State> {
               <div className="page__header">
                 <div className="page__header__image"><img alt={group.name} src={groupImage}/></div>
                 <h1 className="page__title">{group.name}</h1>
-                <h2 className="page__subtitle">Y'all better make some calls for this team</h2>
+                <h2 className="page__subtitle">{group.subtitle}</h2>
               </div>
               <CallCount
                 totalCount={group.totalCalls}

--- a/src/components/home/Why5calls.tsx
+++ b/src/components/home/Why5calls.tsx
@@ -26,7 +26,6 @@ export const Why5calls: React.StatelessComponent<Props> = (props: Props) => (
     <div className="hypothesis__text">
       <CallCount
         totalCount={props.totalCount}
-        large={true}
         t={i18n.t}
       />
       <hr />

--- a/src/components/myimpact/MyImpact.tsx
+++ b/src/components/myimpact/MyImpact.tsx
@@ -49,7 +49,6 @@ export const MyImpact: React.StatelessComponent<Props> = (props: Props) => {
 
       <CallCount
         totalCount={props.totalCount}
-        large={true}
         t={i18n.t}
       />
     </section>

--- a/src/components/myimpact/__snapshots__/MyImpact.test.tsx.snap
+++ b/src/components/myimpact/__snapshots__/MyImpact.test.tsx.snap
@@ -25,7 +25,6 @@ ShallowWrapper {
         />
     </div>
     <Translate(Component)
-        large={true}
         t={[Function]}
         totalCount={1000}
     />
@@ -48,7 +47,6 @@ ShallowWrapper {
             />
       </div>
       <Translate(Component)
-            large={true}
             t={[Function]}
             totalCount={1000}
       />
@@ -125,7 +123,6 @@ ShallowWrapper {
                     />
           </div>
           <Translate(Component)
-                    large={true}
                     t={[Function]}
                     totalCount={1000}
           />
@@ -148,7 +145,6 @@ ShallowWrapper {
                     />
           </div>
           <Translate(Component)
-                    large={true}
                     t={[Function]}
                     totalCount={1000}
           />

--- a/src/components/shared/CallCount.tsx
+++ b/src/components/shared/CallCount.tsx
@@ -43,7 +43,10 @@ export const CallCount: React.StatelessComponent<Props> = (props: Props) => {
   const pctDone = (props.totalCount / callGoal) * 100;
   const pctStyle = {width: `${pctDone}%`};    
 
-  const callText = props.minimal ? `${formatNumber(props.totalCount)} Calls` : `Together we've made ${formatNumber(props.totalCount)} Calls!`;
+  const callText = props.minimal ?
+    `${formatNumber(props.totalCount)} Calls`
+    :
+    `Together we've made ${formatNumber(props.totalCount)} Calls!`;
 
   return (
     <div>

--- a/src/components/shared/CallCount.tsx
+++ b/src/components/shared/CallCount.tsx
@@ -5,22 +5,52 @@ import { formatNumber } from '../shared/utils';
 
 export interface Props {
   readonly totalCount: number;
-  readonly large: boolean;
+  // readonly large: boolean;
+  readonly minimal?: boolean;
   readonly t: TranslationFunction;
 }
 
 export const CallCount: React.StatelessComponent<Props> = (props: Props) => {
-  const pctDone = (props.totalCount / 2000000) * 100;
+  let callGoal = 100;
+  if (props.totalCount >= 100) {
+    callGoal = 500;
+  }
+  if (props.totalCount >= 500) {
+    callGoal = 1000;
+  }
+  if (props.totalCount >= 1000) {
+    callGoal = 5000;
+  }
+  if (props.totalCount >= 5000) {
+    callGoal = 10000;
+  }
+  if (props.totalCount >= 10000) {
+    callGoal = 50000;
+  }
+  if (props.totalCount >= 50000) {
+    callGoal = 100000;
+  }
+  if (props.totalCount >= 100000) {
+    callGoal = 500000;
+  }
+  if (props.totalCount >= 500000) {
+    callGoal = 1000000;
+  }
+  if (props.totalCount >= 1000000) {
+    callGoal = 2000000;
+  }
+
+  const pctDone = (props.totalCount / callGoal) * 100;
   const pctStyle = {width: `${pctDone}%`};    
 
-  const className = props.large ? ' progress__large' : '';
+  const callText = props.minimal ? `${formatNumber(props.totalCount)} Calls` : `Together we've made ${formatNumber(props.totalCount)} Calls!`;
 
   return (
     <div>
-      <div className={`progress${className}`}>
-        <p className="totaltext">Together we've made {formatNumber(props.totalCount)} Calls!</p>
+      <div className="progress progress__large">
+        <p className="totaltext">{callText}</p>
         <span className="progress__border">&nbsp;</span>
-        <span className="progress__goal">{formatNumber(2000000)}</span>
+        <span className="progress__goal">{formatNumber(callGoal)}</span>
         <span style={pctStyle} className="progress__total" />
       </div>
     </div>

--- a/src/components/shared/scss/_group.scss
+++ b/src/components/shared/scss/_group.scss
@@ -1,17 +1,38 @@
 .page__group {
   position: relative;
 
-  .progress {
-    background-color: transparent;
+  .page__header {
+    margin: 24px 0 28px 0;
+
+    img {
+      float: left;
+      height: 60px;
+      max-width: 120px;
+      margin: 0 15px 4px 0;
+    }
   }
 
   .page__title {
-    font-size: 48px;
-    margin-bottom: 10px;
+    font-size: 28px;
+    margin: 0 0 4px 75px;
   }
 
-  h2 {
-    margin-top: 42px;
+  .page__subtitle {
+    font-size: 22px;
+    font-weight: normal;
+    margin: 0 0 0 75px;
+  }
+
+  blockquote {
+    background-color: #ddd;
+    border-radius: 6px;
+    padding: 10px 14px;
+    -webkit-margin-start: 10px;
+    -webkit-margin-end: 10px;    
+
+    p {
+      margin-bottom: 0;
+    }
   }
 
   &__image {

--- a/src/redux/callState/asyncActionCreator.ts
+++ b/src/redux/callState/asyncActionCreator.ts
@@ -121,5 +121,12 @@ export function submitFlexibleOutcome(data: FlexibleOutcomeData) {
         // tslint:disable-next-line:no-console
         .catch(e => console.error('Problem posting outcome data', e));
     }
+
+    // these are really only relevant for non-fetch contact lists
+    if (data.numberContactsLeft === 0) {
+      return dispatch(completeIssueActionCreator());
+    } else {
+      return dispatch(moveToNextActionCreator());
+    }
   };
 }


### PR DESCRIPTION
Examples below. This will make it easier to customize groups with images and titles/subtitles.

Still needed:
* `<p>` margin inside block quotes
* Hook up the subtitle to a group field

<img width="808" alt="screen shot 2017-11-01 at 10 03 41 am" src="https://user-images.githubusercontent.com/49688/32286857-158b6132-beec-11e7-8c84-840c81f78088.png">
<img width="814" alt="screen shot 2017-11-01 at 10 03 49 am" src="https://user-images.githubusercontent.com/49688/32286858-15b2cf10-beec-11e7-8640-948e9b8f56f1.png">