### PR TITLE
Remove legacy issue migration

### DIFF
--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -7,7 +7,7 @@ import { setCachedCity, setLocation, setLocationFetchType,
   setSplitDistrict, setUiState } from '../location/index';
 import { getLocationByIP, getBrowserGeolocation, GEOLOCATION_TIMEOUT } from '../../services/geolocationServices';
 import { issuesActionCreator, groupIssuesActionCreator, callCountActionCreator } from './index';
-import { completeIssueActionCreator, clearContactIndexes } from '../callState/';
+import { clearContactIndexes } from '../callState/';
 import { ApplicationState } from '../root';
 import { LocationUiState } from '../../common/model';
 /**
@@ -210,9 +210,7 @@ export const startup = () => {
     const state = getState();
     // clear contact indexes loaded from local storage
     dispatch(clearContactIndexes());
-    // add completed issues from Choo app in localStorage to
-    // this apps callState.completedIssueIds
-    migrateLegacyCompletedIssues(dispatch);
+
     const loc = state.locationState.address;
     if (loc) {
       // console.log('Using cached address');
@@ -225,16 +223,4 @@ export const startup = () => {
     }
     dispatch(fetchCallCount());
   };
-};
-
-const migrateLegacyCompletedIssues = (dispatch: Dispatch<ApplicationState>) => {
-  const LEGACY_COMPLETED_ISSUES_KEY = 'org.5calls.completed';
-  const legacyCompletedIssues = localStorage.getItem(LEGACY_COMPLETED_ISSUES_KEY);
-  if (legacyCompletedIssues) {
-    const ids = JSON.parse(legacyCompletedIssues);
-    ids.forEach((id) => {
-      dispatch(completeIssueActionCreator(id));
-    });
-    localStorage.removeItem(LEGACY_COMPLETED_ISSUES_KEY);
-  }
 };


### PR DESCRIPTION
This is the largest cause of js errors in sentry, not entirely sure why. At this point it makes more sense to remove than continue to migrate.