### PR TITLE
Implement group/team info caching per issue #367

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -14,6 +14,11 @@ export const DONATE_URL = 'https://secure.actblue.com/donate/5calls-donate';
 
 export const zipCodeRegex: RegExp = /^\d{5}(-\d{4})?$/;
 
+export const cacheTimeout = {
+  default:  24 * 60 * 60 * 1000, // 1 day
+  groups: 24 * 60 * 60 * 1000 // 1 day
+};
+
 export const contact = {
   email: 'make5calls@gmail.com',
   github: 'https://github.com/5calls',

--- a/src/common/model.ts
+++ b/src/common/model.ts
@@ -94,6 +94,17 @@ export interface Group {
 }
 
 /**
+ * Group data to be cached, which includes a
+ * timestamp to determine if the cache needs
+ * to be refreshed.
+ *
+ */
+export interface CacheableGroup {
+  group: Group;
+  timestamp: number;
+}
+
+/**
  * Represents the place used to get location.
  * It may be one of three options:
  * 1. CACHED_ADDRESS - address stored in local storage

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -12,7 +12,7 @@ import { newLocationLookup, clearAddress } from '../redux/location';
 import { CallState } from '../redux/callState/reducer';
 import { selectIssueActionCreator } from '../redux/callState';
 import { ApplicationState } from '../redux/root';
-import { Issue } from '../common/model';
+import { Issue, Group } from '../common/model';
 
 import { SidebarHeader, Sidebar, Footer, Header } from './layout';
 
@@ -51,14 +51,14 @@ const NotFoundPage: React.StatelessComponent<AllProps> = (props: AllProps) => {
       <Footer
         t={i18n.t}
       />
-    </div>    
+    </div>
   );
 };
 
 interface OwnProps {
   readonly issueId?: string;
   readonly issues?: Issue[];
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
 }
 
 interface Props {

--- a/src/components/NotFoundPage.tsx
+++ b/src/components/NotFoundPage.tsx
@@ -12,7 +12,7 @@ import { newLocationLookup, clearAddress } from '../redux/location';
 import { CallState } from '../redux/callState/reducer';
 import { selectIssueActionCreator } from '../redux/callState';
 import { ApplicationState } from '../redux/root';
-import { Issue, Group } from '../common/model';
+import { Issue, CacheableGroup } from '../common/model';
 
 import { SidebarHeader, Sidebar, Footer, Header } from './layout';
 
@@ -58,7 +58,7 @@ const NotFoundPage: React.StatelessComponent<AllProps> = (props: AllProps) => {
 interface OwnProps {
   readonly issueId?: string;
   readonly issues?: Issue[];
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
 }
 
 interface Props {

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -52,8 +52,6 @@ interface Props extends RouteProps {
   readonly onSelectIssue: (issueId: string) => Function;
   readonly onGetIssuesIfNeeded: () => Function;
   readonly clearLocation: () => void;
-  readonly pageGroup: Group;
-
 }
 
 export interface State {
@@ -124,18 +122,19 @@ class CallPage extends React.Component<Props, State> {
   }
 
   getView() {
+    const currentGroup = this.props.currentGroup ? this.props.currentGroup : undefined;
     if (this.props.currentIssue &&
         this.props.currentIssue.contactType &&
         this.props.currentIssue.contactType === 'FETCH') {
-      return (
+        return (
         <LayoutContainer
           issues={this.props.issues}
           issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
-          currentGroup={this.props.currentGroup ? this.props.currentGroup : undefined}
+          currentGroup={currentGroup}
         >
           <FetchCall
             issue={this.props.currentIssue}
-            currentGroup={this.props.currentGroup}
+            currentGroup={currentGroup}
             callState={this.props.callState}
             locationState={this.props.locationState}
             clearLocation={this.props.clearLocation}
@@ -149,7 +148,7 @@ class CallPage extends React.Component<Props, State> {
         <LayoutContainer
           issues={this.props.issues}
           issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
-          currentGroup={this.props.currentGroup ? this.props.currentGroup : undefined}
+          currentGroup={currentGroup}
         >
           <Helmet>
             <title>

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -45,7 +45,7 @@ interface RouteProps extends RouteComponentProps<any> { }
 interface Props extends RouteProps {
   readonly issues: Issue[];
   readonly currentIssue: Issue;
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
   readonly onSubmitOutcome: (data: OutcomeData) => Function;
@@ -131,11 +131,11 @@ class CallPage extends React.Component<Props, State> {
         <LayoutContainer
           issues={this.props.issues}
           issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
-          currentGroupId={this.props.currentGroupId ? this.props.currentGroupId : undefined}
+          currentGroup={this.props.currentGroup ? this.props.currentGroup : undefined}
         >
           <FetchCall
             issue={this.props.currentIssue}
-            currentGroupId={this.props.currentGroupId}
+            currentGroup={this.props.currentGroup}
             callState={this.props.callState}
             locationState={this.props.locationState}
             clearLocation={this.props.clearLocation}
@@ -149,7 +149,7 @@ class CallPage extends React.Component<Props, State> {
         <LayoutContainer
           issues={this.props.issues}
           issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
-          currentGroupId={this.props.currentGroupId ? this.props.currentGroupId : undefined}
+          currentGroup={this.props.currentGroup ? this.props.currentGroup : undefined}
         >
           <Helmet>
             <title>

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 
 import { CallTranslatable, FetchCall } from './index';
 import { LayoutContainer } from '../layout';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
@@ -52,6 +52,8 @@ interface Props extends RouteProps {
   readonly onSelectIssue: (issueId: string) => Function;
   readonly onGetIssuesIfNeeded: () => Function;
   readonly clearLocation: () => void;
+  readonly pageGroup: Group;
+
 }
 
 export interface State {
@@ -122,8 +124,8 @@ class CallPage extends React.Component<Props, State> {
   }
 
   getView() {
-    if (this.props.currentIssue && 
-        this.props.currentIssue.contactType && 
+    if (this.props.currentIssue &&
+        this.props.currentIssue.contactType &&
         this.props.currentIssue.contactType === 'FETCH') {
       return (
         <LayoutContainer
@@ -166,7 +168,7 @@ class CallPage extends React.Component<Props, State> {
             t={i18n.t}
           />
         </LayoutContainer>
-      );  
+      );
     }
   }
 

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -5,7 +5,7 @@ import { Helmet } from 'react-helmet';
 
 import { CallTranslatable, FetchCall } from './index';
 import { LayoutContainer } from '../layout';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
@@ -45,7 +45,7 @@ interface RouteProps extends RouteComponentProps<any> { }
 interface Props extends RouteProps {
   readonly issues: Issue[];
   readonly currentIssue: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly callState: CallState;
   readonly locationState: LocationState;
   readonly onSubmitOutcome: (data: OutcomeData) => Function;

--- a/src/components/call/FetchCall.tsx
+++ b/src/components/call/FetchCall.tsx
@@ -4,7 +4,7 @@ import i18n from '../../services/i18n';
 import { TranslationFunction } from 'i18next';
 import * as ReactMarkdown from 'react-markdown';
 
-import { Issue, VoterContact, Group } from '../../common/model';
+import { Issue, VoterContact, CacheableGroup } from '../../common/model';
 import { CallHeaderTranslatable } from './index';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
@@ -14,7 +14,7 @@ import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 // This defines the props that we must pass into this component.
 export interface Props {
   readonly issue: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly callState: CallState;
   readonly locationState: LocationState;
   readonly t: TranslationFunction;

--- a/src/components/call/FetchCall.tsx
+++ b/src/components/call/FetchCall.tsx
@@ -4,7 +4,7 @@ import i18n from '../../services/i18n';
 import { TranslationFunction } from 'i18next';
 import * as ReactMarkdown from 'react-markdown';
 
-import { Issue, VoterContact } from '../../common/model';
+import { Issue, VoterContact, Group } from '../../common/model';
 import { CallHeaderTranslatable } from './index';
 import { CallState, OutcomeData } from '../../redux/callState';
 import { LocationState } from '../../redux/location/reducer';
@@ -14,7 +14,7 @@ import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 // This defines the props that we must pass into this component.
 export interface Props {
   readonly issue: Issue;
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
   readonly t: TranslationFunction;
@@ -119,7 +119,7 @@ export default class FetchCall extends React.Component<Props, State> {
     if (this.supportEnabled()) {
       return (
       <div className="call__outcomes__items call__outcomes__support">
-        {buttons.map((button, index) => 
+        {buttons.map((button, index) =>
           <button key={index} onClick={(e) => this.setSupport(e, button.key)} className={this.buttonClass(button.key)}>
             {button.title}<br/>{button.emoji}
           </button>
@@ -130,7 +130,7 @@ export default class FetchCall extends React.Component<Props, State> {
 
     return (
       <div className="call__outcomes__items call__outcomes__support disabled">
-        {buttons.map((button, index) => 
+        {buttons.map((button, index) =>
           <button key={index} disabled={true}>{button.title}<br/>{button.emoji}</button>
         )}
       </div>
@@ -237,11 +237,11 @@ export default class FetchCall extends React.Component<Props, State> {
             )}
           </div>
           <h3 className="call__outcomes__header">
-            If contacted: do they support Danica? Use your judgment.    
+            If contacted: do they support Danica? Use your judgment.
           </h3>
           {this.supportButtons()}
           <h3 className="call__outcomes__header">
-            Done? Move on to the next voter           
+            Done? Move on to the next voter
           </h3>
           {this.nextButton()}
         </div>
@@ -250,7 +250,7 @@ export default class FetchCall extends React.Component<Props, State> {
     }
 
     if (!this.state.checkedForContact) {
-      return <h3 className="call__outcomes__header">Getting your next contact...</h3>;      
+      return <h3 className="call__outcomes__header">Getting your next contact...</h3>;
     } else {
       return (
         <blockquote>
@@ -258,7 +258,7 @@ export default class FetchCall extends React.Component<Props, State> {
           {/*tslint:disable-next-line:max-line-length*/}
           <p>Looks like we're all out of calls to make for today, or we're outside of normal calling hours (9am-9pm in the local time zone). Come back tomorrow for more calls!</p>
         </blockquote>
-      );      
+      );
     }
   }
 

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -3,21 +3,20 @@ import { bindActionCreators } from 'redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { ApplicationState } from '../../redux/root';
 import { CallPage } from '../call/index';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 import { getIssue } from '../shared/utils';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
 import { clearAddress } from '../../redux/location';
 import { findCacheableGroup } from '../../redux/cache';
-import { hasGroupCacheTimeoutExceeded } from '../../redux/cache/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
 interface StateProps {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly callState: CallState;
   readonly locationState: LocationState;
 }
@@ -43,17 +42,9 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
 
   const groupId = ownProps.match.params.groupid;
   const cgroup = findCacheableGroup(groupId, state.appCache);
-  let group: Group | undefined;
-  if (cgroup) {
-    group = cgroup.group;
-    // If cached group has timed-out, than set group to
-    // undefined so an API call will be done to refresh the data
-    if (hasGroupCacheTimeoutExceeded({ timestamp: cgroup.timestamp})) {
-      group = undefined;
-    }
-  }
+
   return {
-    currentGroup: group,
+    currentGroup: cgroup,
     issues: groupPageIssues,
     currentIssue: currentIssue,
     callState: state.callState,

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -17,7 +17,7 @@ interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: strin
 interface StateProps {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroupId?: String;
+  readonly currentGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
   readonly pageGroup: Group;
@@ -50,7 +50,7 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
     group = cgroup.group;
   }
   return {
-    currentGroupId: groupId,
+    currentGroup: group,
     pageGroup: group,
     issues: groupPageIssues,
     currentIssue: currentIssue,

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -1,15 +1,16 @@
 import { connect, Dispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { ApplicationState } from '../../redux/root';
 import { CallPage } from '../call/index';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { getIssue } from '../shared/utils';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
 import { clearAddress } from '../../redux/location';
-
-import { RouteComponentProps } from 'react-router-dom';
+import { cacheGroup } from '../../redux/cache/asyncActionCreator';
+import { findCacheableGroup } from '../../redux/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -19,6 +20,7 @@ interface StateProps {
   readonly currentGroupId?: String;
   readonly callState: CallState;
   readonly locationState: LocationState;
+  readonly pageGroup: Group;
 }
 
 interface DispatchProps {
@@ -40,8 +42,16 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
 
   const currentIssue: Issue | undefined = getIssue(state.remoteDataState, ownProps.match.params.issueid);
 
+  const groupId = ownProps.match.params.groupid;
+  cacheGroup(groupId);
+  const cgroup = findCacheableGroup(groupId, state.appCache);
+  let group: Group = {} as Group;
+  if (cgroup) {
+    group = cgroup.group;
+  }
   return {
-    currentGroupId: ownProps.match.params.groupid,
+    currentGroupId: groupId,
+    pageGroup: group,
     issues: groupPageIssues,
     currentIssue: currentIssue,
     callState: state.callState,

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -9,8 +9,8 @@ import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
 import { clearAddress } from '../../redux/location';
-import { cacheGroup } from '../../redux/cache/asyncActionCreator';
 import { findCacheableGroup } from '../../redux/cache';
+import { hasGroupCacheTimeoutExceeded } from '../../redux/cache/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -20,7 +20,6 @@ interface StateProps {
   readonly currentGroup?: Group;
   readonly callState: CallState;
   readonly locationState: LocationState;
-  readonly pageGroup: Group;
 }
 
 interface DispatchProps {
@@ -43,15 +42,18 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   const currentIssue: Issue | undefined = getIssue(state.remoteDataState, ownProps.match.params.issueid);
 
   const groupId = ownProps.match.params.groupid;
-  cacheGroup(groupId);
   const cgroup = findCacheableGroup(groupId, state.appCache);
-  let group: Group = {} as Group;
+  let group: Group | undefined;
   if (cgroup) {
     group = cgroup.group;
+    // If cached group has timed-out, than set group to
+    // undefined so an API call will be done to refresh the data
+    if (hasGroupCacheTimeoutExceeded({ timestamp: cgroup.timestamp})) {
+      group = undefined;
+    }
   }
   return {
     currentGroup: group,
-    pageGroup: group,
     issues: groupPageIssues,
     currentIssue: currentIssue,
     callState: state.callState,

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -8,7 +8,7 @@ import { Group, Issue } from '../../common/model';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { CallCount } from '../shared';
-import { queueUntilRehydration } from '../../redux/rehydrationUtil';
+// import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 import { getGroup } from '../../services/apiServices';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
@@ -59,8 +59,14 @@ class GroupPage extends React.Component<Props, State> {
       getGroup(props.match.params.groupid)
         .then(group => {
           this.setState({pageGroupState: group});
+          if (group) {
+            this.setState({loadingState: GroupLoadingState.FOUND});
+          } else {
+            this.setState({loadingState: GroupLoadingState.NOTFOUND});
+          }
           // Dispatch call to add to cache
           this.props.cacheGroup(group);
+          this.props.onGetIssuesIfNeeded(group.id);
         })
         // tslint:disable-next-line:no-console
         .catch(error => console.log('Problem calling cache/asyncActionCreator.getGroup()', error));
@@ -69,27 +75,30 @@ class GroupPage extends React.Component<Props, State> {
   }
 
   componentWillReceiveProps(newProps: Props) {
-      if (newProps.match.params.groupid) {
-        this.setState({ loadingState: GroupLoadingState.LOADING });
-        this.getGroupDetails(newProps.match.params.groupid);
-      }
+      // if (newProps.match.params.groupid) {
+      //   this.setState({ loadingState: GroupLoadingState.LOADING });
+        // this.getGroupDetails(newProps.match.params.groupid);
+      // }
   }
 
   componentDidMount() {
-    queueUntilRehydration(() => {
-      this.getGroupDetails(this.props.match.params.groupid);
-    });
+    if (this.state.pageGroupState) {
+      this.setState({loadingState: GroupLoadingState.FOUND});
+    }
+    // queueUntilRehydration(() => {
+    //   this.getGroupDetails(this.props.match.params.groupid);
+    // });
   }
 
-  getGroupDetails = (groupid: string) => {
-      if (this.props.pageGroup) {
-        this.props.onGetIssuesIfNeeded(this.props.pageGroup.id);
+  // getGroupDetails = (groupid: string) => {
+  //     if (this.state.pageGroupState && this.state.loadingState !== GroupLoadingState.LOADING) {
+  //       this.props.onGetIssuesIfNeeded(groupid);
 
-        this.setState({ loadingState: GroupLoadingState.FOUND });
-      } else {
-        this.setState({ loadingState: GroupLoadingState.NOTFOUND });
-      }
-  }
+  //       // this.setState({ loadingState: GroupLoadingState.FOUND });
+  //     // } else {
+  //     //   this.setState({ loadingState: GroupLoadingState.NOTFOUND });
+  //     }
+  // }
 
   joinTeam = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.blur();

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -98,7 +98,7 @@ class GroupPage extends React.Component<Props, State> {
       case GroupLoadingState.LOADING:
         return (
           <LayoutContainer
-            currentGroupId={this.props.match.params.groupid}
+            currentGroup={this.state.pageGroupState}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -122,7 +122,7 @@ class GroupPage extends React.Component<Props, State> {
 
         return (
           <LayoutContainer
-            currentGroupId={this.props.match.params.groupid}
+            currentGroup={this.state.pageGroupState}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -144,7 +144,7 @@ class GroupPage extends React.Component<Props, State> {
       default:
         return (
           <LayoutContainer
-            currentGroupId={this.props.match.params.groupid}
+            currentGroup={this.state.pageGroupState}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -5,17 +5,15 @@ import { Link, RouteComponentProps } from 'react-router-dom';
 import * as ReactMarkdown from 'react-markdown';
 
 import { Group, Issue } from '../../common/model';
-// import { formatNumber } from '../shared/utils';
-import { getGroup } from '../../services/apiServices';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { CallCount } from '../shared';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
+import { getGroup } from '../../services/apiServices';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
 interface Props extends RouteProps {
-  readonly activeGroup?: Group; 
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
   readonly completedIssueIds: string[];
@@ -26,11 +24,13 @@ interface Props extends RouteProps {
   readonly onSelectIssue: (issueId: string) => Function;
   readonly onGetIssuesIfNeeded: (groupid: string) => Function;
   readonly onJoinGroup: (group: Group) => Function;
+  readonly pageGroup?: Group;
+  readonly cacheGroup: (group: Group) => Function;
 }
 
 export interface State {
   loadingState: GroupLoadingState;
-  pageGroup?: Group;
+  pageGroupState?: Group;
 }
 
 enum GroupLoadingState {
@@ -44,22 +44,35 @@ class GroupPage extends React.Component<Props, State> {
     super(props);
     // set initial state
     this.state = this.setStateFromProps(props);
+    this.setGroup(props);
   }
 
   setStateFromProps(props: Props): State {
     return {
       loadingState: GroupLoadingState.LOADING,
-      pageGroup: undefined,
+      pageGroupState: props.pageGroup ? props.pageGroup : undefined
     };
   }
 
+  setGroup(props: Props) {
+    if (!this.state.pageGroupState) {
+      getGroup(props.match.params.groupid)
+        .then(group => {
+          this.setState({pageGroupState: group});
+          // Dispatch call to add to cache
+          this.props.cacheGroup(group);
+        })
+        // tslint:disable-next-line:no-console
+        .catch(error => console.log('Problem calling cache/asyncActionCreator.getGroup()', error));
+    }
+
+  }
+
   componentWillReceiveProps(newProps: Props) {
-    if (this.state.pageGroup) {
-      if (newProps.match.params.groupid !== this.state.pageGroup.id) {
+      if (newProps.match.params.groupid) {
         this.setState({ loadingState: GroupLoadingState.LOADING });
         this.getGroupDetails(newProps.match.params.groupid);
-      }      
-    }
+      }
   }
 
   componentDidMount() {
@@ -69,20 +82,20 @@ class GroupPage extends React.Component<Props, State> {
   }
 
   getGroupDetails = (groupid: string) => {
-    getGroup(groupid).then((response: Group) => {      
-      this.props.onGetIssuesIfNeeded(groupid);
+      if (this.props.pageGroup) {
+        this.props.onGetIssuesIfNeeded(this.props.pageGroup.id);
 
-      this.setState({ loadingState: GroupLoadingState.FOUND, pageGroup: response });
-    }).catch((e) => {
-      this.setState({ loadingState: GroupLoadingState.NOTFOUND });
-    });  
+        this.setState({ loadingState: GroupLoadingState.FOUND });
+      } else {
+        this.setState({ loadingState: GroupLoadingState.NOTFOUND });
+      }
   }
 
   joinTeam = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.blur();
 
-    if (this.state.pageGroup) {
-      this.props.onJoinGroup(this.state.pageGroup); 
+    if (this.props.pageGroup) {
+      this.props.onJoinGroup(this.props.pageGroup);
     }
   }
 
@@ -105,8 +118,8 @@ class GroupPage extends React.Component<Props, State> {
 
         // I hate handling optionals this way, swift is so much better on this
         let group: Group;
-        if (this.state.pageGroup) {
-          group = this.state.pageGroup;
+        if (this.state.pageGroupState) {
+          group = this.state.pageGroupState;
         } else {
           return <span/>;
         }
@@ -114,7 +127,7 @@ class GroupPage extends React.Component<Props, State> {
         const groupImage = group.photoURL ? group.photoURL : '/img/5calls-stars.png';
 
         return (
-          <LayoutContainer 
+          <LayoutContainer
             currentGroupId={this.props.match.params.groupid}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
@@ -153,7 +166,7 @@ class GroupPage extends React.Component<Props, State> {
             currentGroupId={this.props.match.params.groupid}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
-          >          
+          >
             <div className="page__group">
               <h2 className="page__title">There's no team here 😢</h2>
             </div>

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import i18n from '../../services/i18n';
 import { LayoutContainer } from '../layout';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import * as ReactMarkdown from 'react-markdown';
 
 import { Group, Issue } from '../../common/model';
@@ -143,19 +143,6 @@ class GroupPage extends React.Component<Props, State> {
                 minimal={true}
                 t={i18n.t}
               />
-              {/* yes, this is terrible */}
-              { (group.id === 'danicaroem') ?
-              <blockquote>
-                {/*tslint:disable-next-line:max-line-length*/}
-                <p>Welcome to the phone bank for Danica Roem, candidate for Virginia’s House of Delegates for District 13!</p>
-                {/*tslint:disable-next-line:max-line-length*/}
-                <p>We'll be making calls to voters in District 13 to help spread the word about Danica and the upcoming election on November 7th.</p>
-                {/*tslint:disable-next-line:max-line-length*/}
-                <p>These are a little different from calling your Congressperson, so before making these important calls, please read through all the materials below and familiarize yourself with Danica.</p>
-                {/*tslint:disable-next-line:max-line-length*/}
-                <p>If you’ve never made voter calls before, that’s perfectly ok! <Link to="/phonebanks">Please head over here</Link> for tips on phone banking and a great video that will make you feel ready!</p>
-              </blockquote>
-              : <span />}
               <ReactMarkdown source={group.description}/>
             </div>
           </LayoutContainer>

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -8,7 +8,7 @@ import { Group, Issue } from '../../common/model';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { CallCount } from '../shared';
-// import { queueUntilRehydration } from '../../redux/rehydrationUtil';
+import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 import { getGroup } from '../../services/apiServices';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
@@ -74,31 +74,16 @@ class GroupPage extends React.Component<Props, State> {
 
   }
 
-  componentWillReceiveProps(newProps: Props) {
-      // if (newProps.match.params.groupid) {
-      //   this.setState({ loadingState: GroupLoadingState.LOADING });
-        // this.getGroupDetails(newProps.match.params.groupid);
-      // }
-  }
-
   componentDidMount() {
     if (this.state.pageGroupState) {
       this.setState({loadingState: GroupLoadingState.FOUND});
+      queueUntilRehydration(() => {
+        this.props.onGetIssuesIfNeeded(this.props.match.params.groupid);
+      });
+    } else {
+      this.setState({loadingState: GroupLoadingState.NOTFOUND});
     }
-    // queueUntilRehydration(() => {
-    //   this.getGroupDetails(this.props.match.params.groupid);
-    // });
   }
-
-  // getGroupDetails = (groupid: string) => {
-  //     if (this.state.pageGroupState && this.state.loadingState !== GroupLoadingState.LOADING) {
-  //       this.props.onGetIssuesIfNeeded(groupid);
-
-  //       // this.setState({ loadingState: GroupLoadingState.FOUND });
-  //     // } else {
-  //     //   this.setState({ loadingState: GroupLoadingState.NOTFOUND });
-  //     }
-  // }
 
   joinTeam = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.blur();

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -3,13 +3,13 @@ import i18n from '../../services/i18n';
 import { LayoutContainer } from '../layout';
 import { RouteComponentProps } from 'react-router-dom';
 import * as ReactMarkdown from 'react-markdown';
-
 import { Group, Issue } from '../../common/model';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { CallCount } from '../shared';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 import { getGroup } from '../../services/apiServices';
+import { CacheableGroup, hasGroupCacheTimeoutExceeded, cacheableGroupFactory } from '../../redux/cache/cache';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -24,19 +24,20 @@ interface Props extends RouteProps {
   readonly onSelectIssue: (issueId: string) => Function;
   readonly onGetIssuesIfNeeded: (groupid: string) => Function;
   readonly onJoinGroup: (group: Group) => Function;
-  readonly pageGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly cacheGroup: (group: Group) => Function;
 }
 
 export interface State {
   loadingState: GroupLoadingState;
-  pageGroupState?: Group;
+  pageGroupState?: CacheableGroup;
 }
 
 enum GroupLoadingState {
   LOADING = 'LOADING',
   FOUND = 'FOUND',
   NOTFOUND = 'NOTFOUND',
+  ERROR = 'ERROR',
 }
 
 class GroupPage extends React.Component<Props, State> {
@@ -50,16 +51,19 @@ class GroupPage extends React.Component<Props, State> {
   setStateFromProps(props: Props): State {
     return {
       loadingState: GroupLoadingState.LOADING,
-      pageGroupState: props.pageGroup ? props.pageGroup : undefined
+      pageGroupState: props.currentGroup ? props.currentGroup : undefined
     };
   }
 
   setGroup(props: Props) {
-    if (!this.state.pageGroupState) {
+    let cgroup = this.state.pageGroupState;
+    // Call the API when page first loads and group
+    // is not in the cache or if the cached value has timed out
+    if (!cgroup || hasGroupCacheTimeoutExceeded({timestamp: cgroup.timestamp})) {
       getGroup(props.match.params.groupid)
         .then(group => {
-          this.setState({pageGroupState: group});
           if (group) {
+            this.setState({pageGroupState: cacheableGroupFactory(group)});
             this.setState({loadingState: GroupLoadingState.FOUND});
           } else {
             this.setState({loadingState: GroupLoadingState.NOTFOUND});
@@ -68,8 +72,16 @@ class GroupPage extends React.Component<Props, State> {
           this.props.cacheGroup(group);
           this.props.onGetIssuesIfNeeded(group.id);
         })
-        // tslint:disable-next-line:no-console
-        .catch(error => console.log('Problem calling cache/asyncActionCreator.getGroup()', error));
+        .catch((error: Error) =>  {
+          // If 404 error, set loading state to NOTFOUND
+          if (error.message.includes('404')) {
+            this.setState({loadingState: GroupLoadingState.NOTFOUND});
+          } else {
+            // tslint:disable-next-line:no-console
+            console.error('Problem calling cache/asyncActionCreator.getGroup()', error);
+            this.setState({loadingState: GroupLoadingState.ERROR});
+          }
+        });
     }
 
   }
@@ -81,15 +93,15 @@ class GroupPage extends React.Component<Props, State> {
         this.props.onGetIssuesIfNeeded(this.props.match.params.groupid);
       });
     } else {
-      this.setState({loadingState: GroupLoadingState.NOTFOUND});
+      this.setState({loadingState: GroupLoadingState.LOADING});
     }
   }
 
   joinTeam = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.blur();
 
-    if (this.props.pageGroup) {
-      this.props.onJoinGroup(this.props.pageGroup);
+    if (this.props.currentGroup) {
+      this.props.onJoinGroup(this.props.currentGroup.group);
     }
   }
 
@@ -98,7 +110,7 @@ class GroupPage extends React.Component<Props, State> {
       case GroupLoadingState.LOADING:
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -108,12 +120,10 @@ class GroupPage extends React.Component<Props, State> {
           </LayoutContainer>
         );
       case GroupLoadingState.FOUND:
-        // const groupId = this.props.activeGroup ? this.props.activeGroup.id : 'nogroup';
-
         // I hate handling optionals this way, swift is so much better on this
         let group: Group;
         if (this.state.pageGroupState) {
-          group = this.state.pageGroupState;
+          group = this.state.pageGroupState.group;
         } else {
           return <span/>;
         }
@@ -122,7 +132,7 @@ class GroupPage extends React.Component<Props, State> {
 
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -141,18 +151,32 @@ class GroupPage extends React.Component<Props, State> {
             </div>
           </LayoutContainer>
         );
-      default:
+      case GroupLoadingState.NOTFOUND:
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
             <div className="page__group">
-              <h2 className="page__title">There's no team here 😢</h2>
+              <h2 className="page__title">There's no team with an ID of '{this.props.match.params.groupid}' 😢</h2>
             </div>
           </LayoutContainer>
         );
+        default:
+          return (
+            <LayoutContainer
+              currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
+              issues={this.props.issues}
+              issueId={this.props.match.params.issueid}
+            >
+              <div className="page__group">
+                { // tslint:disable-next-line:max-line-length
+                }
+                <h2 className="page__title">An error occurred during a request for team '{this.props.match.params.groupid}' 😢</h2>
+              </div>
+            </LayoutContainer>
+          );
     }
   }
 }

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -3,13 +3,13 @@ import i18n from '../../services/i18n';
 import { LayoutContainer } from '../layout';
 import { RouteComponentProps } from 'react-router-dom';
 import * as ReactMarkdown from 'react-markdown';
-import { Group, Issue } from '../../common/model';
+import { Group, Issue, CacheableGroup } from '../../common/model';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { CallCount } from '../shared';
 import { queueUntilRehydration } from '../../redux/rehydrationUtil';
 import { getGroup } from '../../services/apiServices';
-import { CacheableGroup, hasGroupCacheTimeoutExceeded, cacheableGroupFactory } from '../../redux/cache/cache';
+import { hasGroupCacheTimeoutExceeded, cacheableGroupFactory } from '../../redux/cache/cache';
 
 interface RouteProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -110,7 +110,7 @@ class GroupPage extends React.Component<Props, State> {
       case GroupLoadingState.LOADING:
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -132,7 +132,7 @@ class GroupPage extends React.Component<Props, State> {
 
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -154,7 +154,7 @@ class GroupPage extends React.Component<Props, State> {
       case GroupLoadingState.NOTFOUND:
         return (
           <LayoutContainer
-            currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
+            currentGroup={this.state.pageGroupState ? this.state.pageGroupState : undefined}
             issues={this.props.issues}
             issueId={this.props.match.params.issueid}
           >
@@ -166,7 +166,7 @@ class GroupPage extends React.Component<Props, State> {
         default:
           return (
             <LayoutContainer
-              currentGroup={this.state.pageGroupState ? this.state.pageGroupState.group : undefined}
+              currentGroup={this.state.pageGroupState ? this.state.pageGroupState : undefined}
               issues={this.props.issues}
               issueId={this.props.match.params.issueid}
             >

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -9,23 +9,35 @@ import { CallState } from '../../redux/callState/reducer';
 import { selectIssueActionCreator, joinGroupActionCreator } from '../../redux/callState';
 
 import { RouteComponentProps } from 'react-router-dom';
+import { addToCache } from '../../redux/cache/asyncActionCreator';
+import { findCacheableGroup } from '../../redux/cache/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
 interface StateProps {
-  readonly activeGroup?: Group;
   readonly issues: Issue[];
   readonly callState: CallState;
   readonly locationState: LocationState;
+  readonly pageGroup?: Group;
 }
 
 interface DispatchProps {
   readonly onSelectIssue: (issueId: string) => void;
   readonly onGetIssuesIfNeeded: (groupid: string) => void;
   readonly onJoinGroup: (group: Group) => void;
+  readonly cacheGroup: (group: Group) => Function;
 }
 
 const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProps => {
+  // set group if in cache
+  const groupId = ownProps.match.params.groupid;
+  const cgroup = findCacheableGroup(groupId, state.appCache);
+  console.log('Found CachableGroup', cgroup)
+  let group: Group | undefined = undefined;
+  if (cgroup) {
+    group = cgroup.group;
+  }
+
   let groupPageIssues: Issue[] = [];
 
   // send group issues if they exist, normal active ones if they don't
@@ -34,9 +46,9 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   } else {
     groupPageIssues = state.remoteDataState.issues;
   }
-  
+
   return {
-    activeGroup: state.callState.group,
+    pageGroup: group,
     issues: groupPageIssues,
     callState: state.callState,
     locationState: state.locationState,
@@ -49,6 +61,7 @@ const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps
       onSelectIssue: selectIssueActionCreator,
       onGetIssuesIfNeeded: getGroupIssuesIfNeeded,
       onJoinGroup: joinGroupActionCreator,
+      cacheGroup: addToCache
     },
     dispatch);
 };

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -2,7 +2,7 @@ import { connect, Dispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ApplicationState } from '../../redux/root';
 import GroupPage from './GroupPage';
-import { Group, Issue } from '../../common/model';
+import { Group, Issue, CacheableGroup } from '../../common/model';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
@@ -10,7 +10,7 @@ import { selectIssueActionCreator, joinGroupActionCreator } from '../../redux/ca
 
 import { RouteComponentProps } from 'react-router-dom';
 import { addToCache } from '../../redux/cache/asyncActionCreator';
-import { findCacheableGroup, CacheableGroup } from '../../redux/cache/cache';
+import { findCacheableGroup } from '../../redux/cache/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -32,7 +32,6 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   // set group if in cache
   const groupId = ownProps.match.params.groupid;
   const cgroup = findCacheableGroup(groupId, state.appCache);
-  console.log('Found CachableGroup', cgroup)
   let group: Group | undefined = undefined;
   if (cgroup) {
     group = cgroup.group;

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -10,7 +10,7 @@ import { selectIssueActionCreator, joinGroupActionCreator } from '../../redux/ca
 
 import { RouteComponentProps } from 'react-router-dom';
 import { addToCache } from '../../redux/cache/asyncActionCreator';
-import { findCacheableGroup } from '../../redux/cache/cache';
+import { findCacheableGroup, CacheableGroup } from '../../redux/cache/cache';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -18,7 +18,7 @@ interface StateProps {
   readonly issues: Issue[];
   readonly callState: CallState;
   readonly locationState: LocationState;
-  readonly pageGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
 }
 
 interface DispatchProps {
@@ -32,10 +32,6 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   // set group if in cache
   const groupId = ownProps.match.params.groupid;
   const cgroup = findCacheableGroup(groupId, state.appCache);
-  let group: Group | undefined = undefined;
-  if (cgroup) {
-    group = cgroup.group;
-  }
 
   let groupPageIssues: Issue[] = [];
 
@@ -47,7 +43,7 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   }
 
   return {
-    pageGroup: group,
+    currentGroup: cgroup,
     issues: groupPageIssues,
     callState: state.callState,
     locationState: state.locationState,

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -3,13 +3,13 @@ import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { find } from 'lodash';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { IssuesListItem } from './index';
 
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: string;
+  readonly currentGroup?: Group;
   readonly completedIssueIds: string[];
   readonly t: TranslationFunction;
   readonly onSelectIssue: (issueId: string) => void;

--- a/src/components/issues/IssuesList.tsx
+++ b/src/components/issues/IssuesList.tsx
@@ -3,13 +3,13 @@ import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { find } from 'lodash';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 import { IssuesListItem } from './index';
 
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly completedIssueIds: string[];
   readonly t: TranslationFunction;
   readonly onSelectIssue: (issueId: string) => void;

--- a/src/components/issues/IssuesListItem.tsx
+++ b/src/components/issues/IssuesListItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 
 interface Props {
   readonly issue: Issue;
   readonly isIssueComplete: boolean;
   readonly isIssueActive: boolean;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly onSelectIssue: (issueId: string) => void;
 }
 
@@ -21,7 +21,7 @@ export class IssuesListItem extends React.Component<Props, State> {
 
     // need to provide alternative links for on group page
     const issueLink = this.props.currentGroup ?
-      `/team/${this.props.currentGroup.id}/${issueID}` : `/issue/${issueID}`;
+      `/team/${this.props.currentGroup.group.id}/${issueID}` : `/issue/${issueID}`;
     return (
       <li>
         <Link

--- a/src/components/issues/IssuesListItem.tsx
+++ b/src/components/issues/IssuesListItem.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 
 interface Props {
   readonly issue: Issue;
   readonly isIssueComplete: boolean;
   readonly isIssueActive: boolean;
-  readonly currentGroup?: string;
+  readonly currentGroup?: Group;
   readonly onSelectIssue: (issueId: string) => void;
 }
 
@@ -21,7 +21,7 @@ export class IssuesListItem extends React.Component<Props, State> {
 
     // need to provide alternative links for on group page
     const issueLink = this.props.currentGroup ?
-      `/team/${this.props.currentGroup}/${issueID}` : `/issue/${issueID}`;
+      `/team/${this.props.currentGroup.id}/${issueID}` : `/issue/${issueID}`;
     return (
       <li>
         <Link

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import i18n from '../../services/i18n';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 import { SidebarHeader, Sidebar, Footer, Header } from './index';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
   readonly issueId: string;
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import i18n from '../../services/i18n';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { SidebarHeader, Sidebar, Footer, Header } from './index';
 
 interface Props {
@@ -14,7 +14,7 @@ interface Props {
   readonly issueId: string;
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;
@@ -36,7 +36,7 @@ const Layout: React.StatelessComponent<Props> = (props: Props) => (
         <div className="issues">
           <SidebarHeader
             callState={props.callState}
-            currentGroupId={props.currentGroupId}
+            currentGroup={props.currentGroup}
             locationState={props.locationState}
             setLocation={props.setLocation}
             clearLocation={props.clearLocation}
@@ -44,7 +44,7 @@ const Layout: React.StatelessComponent<Props> = (props: Props) => (
           <Sidebar
             issues={props.issues}
             currentIssue={props.currentIssue ? props.currentIssue : undefined}
-            currentGroup={props.currentGroupId}
+            currentGroup={props.currentGroup}
             completedIssueIds={props.completedIssueIds}
             onSelectIssue={props.onSelectIssue}
           />

--- a/src/components/layout/LayoutContainer.tsx
+++ b/src/components/layout/LayoutContainer.tsx
@@ -7,12 +7,12 @@ import { newLocationLookup, clearAddress } from '../../redux/location';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { Layout } from './index';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 
 interface OwnProps {
   readonly issueId?: string;
   readonly issues?: Issue[];
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly children?: {};
   readonly postcards?: boolean;
   readonly extraComponent?: {};
@@ -22,7 +22,7 @@ interface StateProps {
   readonly children?: {};
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;

--- a/src/components/layout/LayoutContainer.tsx
+++ b/src/components/layout/LayoutContainer.tsx
@@ -7,12 +7,12 @@ import { newLocationLookup, clearAddress } from '../../redux/location';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { Layout } from './index';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 
 interface OwnProps {
   readonly issueId?: string;
   readonly issues?: Issue[];
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly children?: {};
   readonly postcards?: boolean;
   readonly extraComponent?: {};
@@ -22,7 +22,7 @@ interface StateProps {
   readonly children?: {};
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly completedIssueIds: string[];
   readonly callState: CallState;
   readonly locationState: LocationState;
@@ -47,7 +47,7 @@ function mapStateToProps(state: ApplicationState, ownProps: OwnProps): StateProp
   return {
     issues: issues,
     currentIssue: currentIssue,
-    currentGroupId: ownProps.currentGroupId,
+    currentGroup: ownProps.currentGroup,
     completedIssueIds: state.callState.completedIssueIds,
     callState: state.callState,
     locationState: state.locationState,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import i18n from '../../services/i18n';
-import { Issue } from '../../common/model';
+import { Issue, Group } from '../../common/model';
 import { IssuesListTranslatable } from '../issues';
 
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: string;
+  readonly currentGroup?: Group;
   readonly completedIssueIds: string[];
   readonly onSelectIssue: (issueId: string) => void;
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import i18n from '../../services/i18n';
-import { Issue, Group } from '../../common/model';
+import { Issue, CacheableGroup } from '../../common/model';
 import { IssuesListTranslatable } from '../issues';
 
 interface Props {
   readonly issues: Issue[];
   readonly currentIssue?: Issue;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly completedIssueIds: string[];
   readonly onSelectIssue: (issueId: string) => void;
 }

--- a/src/components/layout/SidebarHeader.tsx
+++ b/src/components/layout/SidebarHeader.tsx
@@ -5,26 +5,26 @@ import i18n from '../../services/i18n';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { LocationTranslatable } from '../location';
+import { Group } from '../../common/model';
 
 interface Props {
   readonly callState: CallState;
-  readonly currentGroupId?: string;
+  readonly currentGroup?: Group;
   readonly locationState: LocationState;
-  readonly setLocation: (location: string) => void;  
-  readonly clearLocation: () => void;  
+  readonly setLocation: (location: string) => void;
+  readonly clearLocation: () => void;
 }
 
 const SidebarHeader: React.StatelessComponent<Props> = (props: Props) => {
   let headerIntro = <h2>{i18n.t('issues.whatsImportantToYou')}</h2>;
 
-  if (props.currentGroupId) {
+  if (props.currentGroup) {
     headerIntro = (
       <h3>
-        Your&nbsp;
-        <Link to={`/team/${props.currentGroupId}`}>team page</Link>
+        <Link to={`/team/${props.currentGroup.id}`}>{props.currentGroup.name} Home</Link>
       </h3>
     );
-  }  
+  }
 
   return (
     <header className="issues__header" role="banner">

--- a/src/components/layout/SidebarHeader.tsx
+++ b/src/components/layout/SidebarHeader.tsx
@@ -5,11 +5,11 @@ import i18n from '../../services/i18n';
 import { LocationState } from '../../redux/location/reducer';
 import { CallState } from '../../redux/callState/reducer';
 import { LocationTranslatable } from '../location';
-import { Group } from '../../common/model';
+import { CacheableGroup } from '../../common/model';
 
 interface Props {
   readonly callState: CallState;
-  readonly currentGroup?: Group;
+  readonly currentGroup?: CacheableGroup;
   readonly locationState: LocationState;
   readonly setLocation: (location: string) => void;
   readonly clearLocation: () => void;
@@ -21,7 +21,7 @@ const SidebarHeader: React.StatelessComponent<Props> = (props: Props) => {
   if (props.currentGroup) {
     headerIntro = (
       <h3>
-        <Link to={`/team/${props.currentGroup.id}`}>{props.currentGroup.name} Home</Link>
+        <Link to={`/team/${props.currentGroup.group.id}`}>{props.currentGroup.group.name} Home</Link>
       </h3>
     );
   }

--- a/src/redux/cache/action.ts
+++ b/src/redux/cache/action.ts
@@ -1,7 +1,5 @@
 import { Action } from 'redux';
-import { AppCacheAction } from './action';
-import { Group } from '../../common/model';
-// import { AppCache } from './';
+import { CacheableGroup } from './';
 
 export enum AppCacheActionType {
   CACHE_GROUP = 'CACHE_GROUP'
@@ -14,5 +12,5 @@ export interface AppCacheAction extends Action {
 
 export interface CacheGroupAction extends AppCacheAction {
   type: AppCacheActionType.CACHE_GROUP;
-  payload: Group;
+  payload: CacheableGroup;
 }

--- a/src/redux/cache/action.ts
+++ b/src/redux/cache/action.ts
@@ -1,6 +1,5 @@
-import { Group } from './../../common/model';
+import { Group, CacheableGroup } from './../../common/model';
 import { Action } from 'redux';
-import { CacheableGroup } from './';
 
 export enum AppCacheActionType {
   CACHE_GROUP = 'CACHE_GROUP',

--- a/src/redux/cache/action.ts
+++ b/src/redux/cache/action.ts
@@ -1,8 +1,10 @@
+import { Group } from './../../common/model';
 import { Action } from 'redux';
 import { CacheableGroup } from './';
 
 export enum AppCacheActionType {
-  CACHE_GROUP = 'CACHE_GROUP'
+  CACHE_GROUP = 'CACHE_GROUP',
+  ADD_GROUP_TO_CACHE = 'ADD_GROUP_TO_CACHE'
 }
 
 export interface AppCacheAction extends Action {
@@ -13,4 +15,9 @@ export interface AppCacheAction extends Action {
 export interface CacheGroupAction extends AppCacheAction {
   type: AppCacheActionType.CACHE_GROUP;
   payload: CacheableGroup;
+}
+
+export interface AddToCacheAction extends AppCacheAction {
+  type: AppCacheActionType.ADD_GROUP_TO_CACHE;
+  payload: Group;
 }

--- a/src/redux/cache/action.ts
+++ b/src/redux/cache/action.ts
@@ -1,0 +1,18 @@
+import { Action } from 'redux';
+import { AppCacheAction } from './action';
+import { Group } from '../../common/model';
+// import { AppCache } from './';
+
+export enum AppCacheActionType {
+  CACHE_GROUP = 'CACHE_GROUP'
+}
+
+export interface AppCacheAction extends Action {
+  type: AppCacheActionType;
+  payload?: {};
+}
+
+export interface CacheGroupAction extends AppCacheAction {
+  type: AppCacheActionType.CACHE_GROUP;
+  payload: Group;
+}

--- a/src/redux/cache/actionCreator.ts
+++ b/src/redux/cache/actionCreator.ts
@@ -1,5 +1,5 @@
-import { Group } from './../../common/model';
-import { CacheGroupAction, AppCacheActionType, CacheableGroup } from './';
+import { Group, CacheableGroup } from './../../common/model';
+import { CacheGroupAction, AppCacheActionType } from './';
 
 export const cacheGroupActionCreator = (cgroup: CacheableGroup): CacheGroupAction => {
   return {

--- a/src/redux/cache/actionCreator.ts
+++ b/src/redux/cache/actionCreator.ts
@@ -1,0 +1,9 @@
+import { Group } from '../../common/model';
+import { CacheGroupAction, AppCacheActionType } from './';
+
+export const cacheGroupActionCreator = (group: Group): CacheGroupAction => {
+  return {
+    type: AppCacheActionType.CACHE_GROUP,
+    payload: group
+  };
+};

--- a/src/redux/cache/actionCreator.ts
+++ b/src/redux/cache/actionCreator.ts
@@ -1,8 +1,16 @@
+import { Group } from './../../common/model';
 import { CacheGroupAction, AppCacheActionType, CacheableGroup } from './';
 
 export const cacheGroupActionCreator = (cgroup: CacheableGroup): CacheGroupAction => {
   return {
     type: AppCacheActionType.CACHE_GROUP,
     payload: cgroup
+  };
+};
+
+export const addGroupToCache = (group: Group) => {
+  return {
+    type: AppCacheActionType.ADD_GROUP_TO_CACHE,
+    payload: group
   };
 };

--- a/src/redux/cache/actionCreator.ts
+++ b/src/redux/cache/actionCreator.ts
@@ -1,9 +1,8 @@
-import { Group } from '../../common/model';
-import { CacheGroupAction, AppCacheActionType } from './';
+import { CacheGroupAction, AppCacheActionType, CacheableGroup } from './';
 
-export const cacheGroupActionCreator = (group: Group): CacheGroupAction => {
+export const cacheGroupActionCreator = (cgroup: CacheableGroup): CacheGroupAction => {
   return {
     type: AppCacheActionType.CACHE_GROUP,
-    payload: group
+    payload: cgroup
   };
 };

--- a/src/redux/cache/asyncActionCreator.test.ts
+++ b/src/redux/cache/asyncActionCreator.test.ts
@@ -1,0 +1,74 @@
+import thunk from 'redux-thunk';
+import configureStore from 'redux-mock-store';
+import * as moxios from 'moxios';
+import { Group } from './../../common/model';
+import {
+  CacheableGroup, AppCache,
+  cacheGroup, AppCacheActionType } from './';
+import { ApplicationState } from './../root';
+
+const middlewares = [thunk];
+const mockStore = configureStore(middlewares);
+
+beforeEach(() => {
+  moxios.install();
+});
+
+afterEach(() => {
+  moxios.uninstall();
+});
+
+// TODO: Needs work - no actions are dispatched
+test('fetchGroup() action creator functions correctly', ( ) => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  const groupId = 'craig';
+  const group: Group = getMockGroup(groupId);
+  moxios.stubRequest(/`group\/${groupId}`/, { response: { group } });
+  const expectedType = AppCacheActionType.CACHE_GROUP;
+  const initialState = {} as ApplicationState;
+  // create a group to initialize in the app cache
+  const group1: Group = getMockGroup('nick');
+  const cgroup1: CacheableGroup = {group: group1, timestamp: new Date().getTime()};
+  const appCache = new AppCache([cgroup1]);
+  initialState.appCache = appCache;
+  const store = mockStore(initialState);
+  store.dispatch(cacheGroup(groupId))
+    .then(() => {
+      const actions = store.getActions();
+      console.log('Actions', actions);
+      expect(actions[0].type).toEqual(expectedType);
+      expect(actions[0].payload.group).toEqual(group);
+      console.log('App Cache', initialState.appCache);
+    })
+    // tslint:disable-next-line:no-console
+    .catch((error) => {
+      console.log('Test Failure: ', error);
+      // done();
+    });
+});
+
+const getMockGroup = (groupId): Group => {
+  const mockResponse: Group = {
+    id: groupId,
+    name: `${groupId} group`,
+    description: `${groupId} description`,
+    photoURL: `http://${groupId}.com`,
+    subtitle: `${groupId} subtitle`,
+    totalCalls: 99
+  };
+  return mockResponse;
+};
+
+// test('fetchCallCount() action creator dispatches proper action', () => {
+//   const count = 999999;
+//   const expectedType = RemoteDataActionType.GET_CALL_TOTAL;
+//   moxios.stubRequest(/counts/, { response: { count} });
+//   const initialState = {} as ApplicationState;
+//   const store = mockStore(initialState);
+//   store.dispatch(fetchCallCount())
+//     .then(() => {
+//       const actions = store.getActions();
+//       expect(actions[0].type).toEqual(expectedType);
+//       expect(actions[0].payload).toEqual(count);
+//     });
+// });

--- a/src/redux/cache/asyncActionCreator.test.ts
+++ b/src/redux/cache/asyncActionCreator.test.ts
@@ -32,14 +32,14 @@ test('fetchGroup() action creator functions correctly', ( ) => {
   const appCache = new AppCache([cgroup1]);
   initialState.appCache = appCache;
   const store = mockStore(initialState);
-  console.log('Store actions', store.getActions());
+  // console.log('Store actions', store.getActions());
   store.dispatch(cacheGroup(groupId))
     .then(() => {
       const actions = store.getActions();
-      console.log('Actions', actions);
+      // console.log('Actions', actions);
       expect(actions[0].type).toEqual(expectedType);
       expect(actions[0].payload.group).toEqual(group);
-      console.log('App Cache', initialState.appCache);
+      // console.log('App Cache', initialState.appCache);
     })
     .catch((error) => {
       // tslint:disable-next-line:no-console

--- a/src/redux/cache/asyncActionCreator.test.ts
+++ b/src/redux/cache/asyncActionCreator.test.ts
@@ -32,6 +32,7 @@ test('fetchGroup() action creator functions correctly', ( ) => {
   const appCache = new AppCache([cgroup1]);
   initialState.appCache = appCache;
   const store = mockStore(initialState);
+  console.log('Store actions', store.getActions());
   store.dispatch(cacheGroup(groupId))
     .then(() => {
       const actions = store.getActions();
@@ -40,10 +41,10 @@ test('fetchGroup() action creator functions correctly', ( ) => {
       expect(actions[0].payload.group).toEqual(group);
       console.log('App Cache', initialState.appCache);
     })
-    // tslint:disable-next-line:no-console
     .catch((error) => {
+      // tslint:disable-next-line:no-console
       console.log('Test Failure: ', error);
-      // done();
+      throw new Error(error.message);
     });
 });
 

--- a/src/redux/cache/asyncActionCreator.test.ts
+++ b/src/redux/cache/asyncActionCreator.test.ts
@@ -1,10 +1,9 @@
 import thunk from 'redux-thunk';
 import configureStore from 'redux-mock-store';
 import * as moxios from 'moxios';
-import { Group } from './../../common/model';
+import { Group, CacheableGroup } from './../../common/model';
 import {
-  CacheableGroup, AppCache,
-  cacheGroup, AppCacheActionType } from './';
+  AppCache, cacheGroup, AppCacheActionType } from './';
 import { ApplicationState } from './../root';
 
 const middlewares = [thunk];

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -2,10 +2,10 @@ import { Dispatch } from 'react-redux';
 import { ApplicationState } from '../root';
 import { cacheGroupActionCreator, addGroupToCache } from './actionCreator';
 import {
-  CacheableGroup, hasGroupCacheTimeoutExceeded,
+  hasGroupCacheTimeoutExceeded,
   findCacheableGroup, cacheableGroupFactory } from './cache';
 import * as api from '../../services/apiServices';
-import { Group } from '../../common/model';
+import { Group, CacheableGroup } from '../../common/model';
 
 export const cacheGroup = (groupId: string) => {
   return (

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -1,13 +1,29 @@
 import { Dispatch } from 'react-redux';
 import { ApplicationState } from '../root';
-import { Group } from '../../common/model';
+import { cacheGroupActionCreator } from './actionCreator';
+import { CacheableGroup, hasGroupCacheTimeoutExceeded, findCacheableGroup, cacheableGroupFactory } from './cache';
+import { getGroup } from '../../services/apiServices';
 
-export function cacheGroup(group: Group) {
+export function cacheGroup(groupId: string) {
   return (
     dispatch: Dispatch<ApplicationState>,
     getState: () => ApplicationState) => {
       const state = getState();
       const appCache = state.appCache;
-      // TODO
+      let cacheable: CacheableGroup | undefined = findCacheableGroup(groupId, appCache);
+      // Call API to get group data if group is not found
+      // in cache or cache timeout has exceeded.
+      if ( cacheable && cacheable.group &&
+        (!cacheable.group[groupId]
+        || hasGroupCacheTimeoutExceeded({ timestamp: cacheable.timestamp }))) {
+        getGroup(groupId)
+          .then(group => {
+            const cacheableGroup = cacheableGroupFactory(group);
+            cacheGroupActionCreator(cacheableGroup);
+          });
+
+      }
+      // TODO - should data be refreshed after a call
+      //    is made since it increments the group's call total.
     };
 }

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -10,7 +10,8 @@ import { Group } from '../../common/model';
 export const cacheGroup = (groupId: string) => {
   return (
     dispatch: Dispatch<ApplicationState>,
-    getState: () => ApplicationState): Promise<void> => {
+    getState: () => ApplicationState
+  ): Promise<void> => {
       const state = getState();
       const appCache = state.appCache;
       let cacheable: CacheableGroup | undefined = findCacheableGroup(groupId, appCache);
@@ -21,24 +22,16 @@ export const cacheGroup = (groupId: string) => {
         return api.getGroup(groupId)
           .then(group => {
             const cacheableGroup = cacheableGroupFactory(group);
-            dispatch(cacheGroupActionCreator(cacheableGroup));
-            // TODO: dispatch an action???
-            // dispatch(foobar(group))
+            if (cacheableGroup) {
+              dispatch(cacheGroupActionCreator(cacheableGroup));
+            }
+            return Promise.resolve();
           });
-
       } else {
         // cacheable group is already in cache
-
-        // get group from cache
-        // const cgroup: CacheableGroup | undefined = findCacheableGroup(groupId, appCache);
-        // const group = cgroup ? cgroup.group : {} as Group;
-        // TODO: dispatch an action???
-        // dispatch(foobar(group))
         return Promise.resolve();
       }
 
-      // TODO - should data be refreshed after a call
-      //    is made since it increments the group's call total.
     };
 };
 

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -1,29 +1,53 @@
 import { Dispatch } from 'react-redux';
 import { ApplicationState } from '../root';
-import { cacheGroupActionCreator } from './actionCreator';
-import { CacheableGroup, hasGroupCacheTimeoutExceeded, findCacheableGroup, cacheableGroupFactory } from './cache';
-import { getGroup } from '../../services/apiServices';
+import { cacheGroupActionCreator, addGroupToCache } from './actionCreator';
+import {
+  CacheableGroup, hasGroupCacheTimeoutExceeded,
+  findCacheableGroup, cacheableGroupFactory } from './cache';
+import * as api from '../../services/apiServices';
+import { Group } from '../../common/model';
 
-export function cacheGroup(groupId: string) {
+export const cacheGroup = (groupId: string) => {
   return (
     dispatch: Dispatch<ApplicationState>,
-    getState: () => ApplicationState) => {
+    getState: () => ApplicationState): Promise<void> => {
       const state = getState();
       const appCache = state.appCache;
       let cacheable: CacheableGroup | undefined = findCacheableGroup(groupId, appCache);
       // Call API to get group data if group is not found
       // in cache or cache timeout has exceeded.
-      if ( cacheable && cacheable.group &&
-        (!cacheable.group[groupId]
-        || hasGroupCacheTimeoutExceeded({ timestamp: cacheable.timestamp }))) {
-        getGroup(groupId)
+      if ( !cacheable ||
+        hasGroupCacheTimeoutExceeded({ timestamp: cacheable.timestamp })) {
+        return api.getGroup(groupId)
           .then(group => {
+            console.log('Group looked up', group);
             const cacheableGroup = cacheableGroupFactory(group);
-            cacheGroupActionCreator(cacheableGroup);
+            dispatch(cacheGroupActionCreator(cacheableGroup));
+            // TODO: dispatch an action???
+            // dispatch(foobar(group))
           });
 
+      } else {
+        // cacheable group is already in cache
+
+        // get group from cache
+        // const cgroup: CacheableGroup | undefined = findCacheableGroup(groupId, appCache);
+        // const group = cgroup ? cgroup.group : {} as Group;
+        // TODO: dispatch an action???
+        // dispatch(foobar(group))
+        return Promise.resolve();
       }
+
       // TODO - should data be refreshed after a call
       //    is made since it increments the group's call total.
     };
-}
+};
+
+export const addToCache = (group: Group) => {
+  return (
+    dispatch: Dispatch<ApplicationState>,
+    getState: () => ApplicationState): Promise<void> => {
+      dispatch(addGroupToCache(group));
+      return Promise.resolve();
+    };
+};

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -1,0 +1,13 @@
+import { Dispatch } from 'react-redux';
+import { ApplicationState } from '../root';
+import { Group } from '../../common/model';
+
+export function cacheGroup(group: Group) {
+  return (
+    dispatch: Dispatch<ApplicationState>,
+    getState: () => ApplicationState) => {
+      const state = getState();
+      const appCache = state.appCache;
+      // TODO
+    };
+}

--- a/src/redux/cache/asyncActionCreator.ts
+++ b/src/redux/cache/asyncActionCreator.ts
@@ -20,7 +20,6 @@ export const cacheGroup = (groupId: string) => {
         hasGroupCacheTimeoutExceeded({ timestamp: cacheable.timestamp })) {
         return api.getGroup(groupId)
           .then(group => {
-            console.log('Group looked up', group);
             const cacheableGroup = cacheableGroupFactory(group);
             dispatch(cacheGroupActionCreator(cacheableGroup));
             // TODO: dispatch an action???

--- a/src/redux/cache/cache.test.ts
+++ b/src/redux/cache/cache.test.ts
@@ -1,0 +1,53 @@
+import { Group } from '../../common/model';
+import {
+  CacheableGroup,
+  GroupCache,
+  AppCache,
+  findCacheableGroup } from './cache';
+
+const group1: Group = {
+  id: 'craig',
+  name: 'Team Craig',
+  description: 'Craig\'s issues',
+  photoURL: 'http://craig.com/img',
+  subtitle: 'Nick for Prez!',
+  totalCalls: 999
+};
+const group2: Group = {
+  id: 'nick',
+  name: 'Team Nick',
+  description: 'Nick\'s issues',
+  photoURL: 'http://nick.com/img',
+  subtitle: 'I miss Swift!',
+  totalCalls: 888
+};
+
+test('test cache creation', () => {
+  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cache = new AppCache([cgroup1, cgroup2]);
+
+  expect(cache.groups.length).toBe(2);
+  expect(cache.groups[0].group.craig).toBeDefined();
+  expect(cache.groups[1].group.nick).toBeDefined();
+});
+
+test('findCachableGroup() should work', () => {
+  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cache = new AppCache([cgroup1, cgroup2]);
+
+  const cgroup = findCacheableGroup('nick', cache);
+  expect(cgroup.group.nick).toBeDefined();
+  expect(cgroup.group.nick.name).toBe(group2.name);
+  expect(cgroup.group.foobar).toBeUndefined();
+});
+
+test('findCachableGroup() should return undefined if it does not contain a group with the id param', () => {
+  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cache = new AppCache([cgroup1, cgroup2]);
+
+  const cgroup = findCacheableGroup('foobar', cache);
+  expect(cgroup).toBeUndefined();
+});

--- a/src/redux/cache/cache.test.ts
+++ b/src/redux/cache/cache.test.ts
@@ -1,9 +1,11 @@
+import { cacheTimeout } from './../../common/constants';
 import { Group } from '../../common/model';
 import {
   CacheableGroup,
-  GroupCache,
   AppCache,
-  findCacheableGroup } from './cache';
+  findCacheableGroup,
+  hasCacheTimeoutExceeded,
+  hasGroupCacheTimeoutExceeded } from './cache';
 
 const group1: Group = {
   id: 'craig',
@@ -23,31 +25,55 @@ const group2: Group = {
 };
 
 test('test cache creation', () => {
-  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
-  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cgroup1: CacheableGroup = { group: group1 , timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: group2 , timestamp: 987654 };
   const cache = new AppCache([cgroup1, cgroup2]);
 
   expect(cache.groups.length).toBe(2);
-  expect(cache.groups[0].group.craig).toBeDefined();
-  expect(cache.groups[1].group.nick).toBeDefined();
+  expect(cache.groups[0].group.id).toBe('craig');
+  expect(cache.groups[1].group.id).toBe('nick');
 });
 
 test('findCachableGroup() should work', () => {
-  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
-  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cgroup1: CacheableGroup = { group: group1 , timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: group2 , timestamp: 987654 };
   const cache = new AppCache([cgroup1, cgroup2]);
 
   const cgroup = findCacheableGroup('nick', cache);
-  expect(cgroup.group.nick).toBeDefined();
-  expect(cgroup.group.nick.name).toBe(group2.name);
-  expect(cgroup.group.foobar).toBeUndefined();
+  expect(cgroup).toBeDefined();
+  if (cgroup) {
+    expect(cgroup.group).toBeDefined();
+    expect(cgroup.group.name).toBe(group2.name);
+  }
 });
 
 test('findCachableGroup() should return undefined if it does not contain a group with the id param', () => {
-  const cgroup1: CacheableGroup = { group: { craig: group1 }, timestamp: 1234567 };
-  const cgroup2: CacheableGroup = { group: { nick: group2 }, timestamp: 987654 };
+  const cgroup1: CacheableGroup = { group: group1 , timestamp: 1234567 };
+  const cgroup2: CacheableGroup = { group: group2 , timestamp: 987654 };
   const cache = new AppCache([cgroup1, cgroup2]);
 
   const cgroup = findCacheableGroup('foobar', cache);
   expect(cgroup).toBeUndefined();
+});
+
+test('hasTimeoutExceeded() returns false', () => {
+  const now = 120;
+  const timestamp = 50;
+  const timeout = 100;
+
+  expect(hasCacheTimeoutExceeded({ timestamp, now, timeout })).toBeFalsy();
+});
+
+test('hasTimeoutExceeded() returns true', () => {
+  const now = 1000;
+  const timestamp = 880;
+  const timeout = 100;
+
+  expect(hasCacheTimeoutExceeded({ timestamp, now, timeout })).toBeTruthy();
+});
+
+test('hasGroupTimeoutExceeded() returns true using only a timestamp argument', () => {
+  const timestamp = new Date().getTime() - (1.4 * cacheTimeout.groups);
+
+  expect(hasGroupCacheTimeoutExceeded({ timestamp })).toBeTruthy();
 });

--- a/src/redux/cache/cache.test.ts
+++ b/src/redux/cache/cache.test.ts
@@ -1,7 +1,6 @@
 import { cacheTimeout } from './../../common/constants';
-import { Group } from '../../common/model';
+import { Group, CacheableGroup } from '../../common/model';
 import {
-  CacheableGroup,
   AppCache,
   findCacheableGroup,
   hasCacheTimeoutExceeded,

--- a/src/redux/cache/cache.ts
+++ b/src/redux/cache/cache.ts
@@ -43,11 +43,15 @@ export function findCacheableGroup(id: string, cache: AppCache): CacheableGroup 
  *
  * @export
  * @param {Group} group - group to be cached
- * @returns {CacheableGroup}
+ * @returns {CacheableGroup | undefined}
  */
-export function cacheableGroupFactory(group: Group): CacheableGroup {
+export function cacheableGroupFactory(group: Group): CacheableGroup | undefined {
     const now = new Date().getTime();
-    return { group, timestamp: now };
+    if (group) {
+      return { group, timestamp: now };
+    } else {
+      return undefined;
+    }
 }
 
 export function addOrReplaceCacheableGroup(groups: CacheableGroup[], group: Group): CacheableGroup[] {
@@ -55,7 +59,12 @@ export function addOrReplaceCacheableGroup(groups: CacheableGroup[], group: Grou
     const newGroups = groups.filter(cgroup => {
         return cgroup.group.id !== group.id;
     });
-    return [...newGroups, cacheableGroupFactory(group)];
+    const newcgroup = cacheableGroupFactory(group);
+    if (newGroups && newcgroup) {
+        return [...newGroups, newcgroup];
+    } else {
+        return groups;
+    }
 }
 
 /**

--- a/src/redux/cache/cache.ts
+++ b/src/redux/cache/cache.ts
@@ -55,8 +55,7 @@ export function addOrReplaceCacheableGroup(groups: CacheableGroup[], group: Grou
     const newGroups = groups.filter(cgroup => {
         return cgroup.group.id !== group.id;
     });
-    newGroups.push(cacheableGroupFactory(group));
-    return newGroups;
+    return [...newGroups, cacheableGroupFactory(group)];
 }
 
 /**

--- a/src/redux/cache/cache.ts
+++ b/src/redux/cache/cache.ts
@@ -1,5 +1,6 @@
+import { CacheTimeoutData, CacheableGroup } from './cache';
 import { Group } from '../../common/model';
-
+import { cacheTimeout } from './../../common/constants';
 /**
  * Group data to be cached, which includes a
  * timestamp to determine if the cache needs
@@ -7,7 +8,7 @@ import { Group } from '../../common/model';
  *
  */
 export interface CacheableGroup {
-  group: { [key: string]: Group }; // key is the group id
+  group: Group;
   timestamp: number;
 }
 
@@ -32,15 +33,82 @@ export class AppCache {
  * @param {AppCache} cache the cache stored in the redux store
  */
 export function findCacheableGroup(id: string, cache: AppCache): CacheableGroup | undefined {
-    return cache.groups
-        .filter(g => g.group[id])
-        .pop();
+    return cache.groups ? cache.groups
+        .filter(g => g.group.id === id)
+        .pop() : undefined;
     }
 
-// export function findGroup(id: string, cache: AppCache): Group | undefined {
-//     return findCacheableGroup(id, cache).group[id];
-// }
+/**
+ * Factory for `CacheableGroup` objects.
+ *
+ * @export
+ * @param {Group} group - group to be cached
+ * @returns {CacheableGroup}
+ */
+export function cacheableGroupFactory(group: Group): CacheableGroup {
+    const now = new Date().getTime();
+    return { group, timestamp: now };
+}
 
-// export function findGroupTimestamp(id: string, cache: AppCache): number | undefined {
-//     return findCacheableGroup(id, cache).timestamp;
-// }
+export function addOrReplaceCacheableGroup(groups: CacheableGroup[], group: Group): CacheableGroup[] {
+    // remove old group if present
+    const newGroups = groups.filter(cgroup => {
+        return cgroup.group.id !== group.id;
+    });
+    newGroups.push(cacheableGroupFactory(group));
+    return newGroups;
+}
+
+/**
+ * Holds data to determine if cached data has timed out.
+ * The `timestamp` field is the only required field
+ * as it is the timestamp that is used to determine if
+ * a timeout has exceeded.
+ * The `now` field represents the current timestamp, which
+ * by default should be the value of new Date().getTime()
+ * The `timeout` field is the timeout value (in milliseconds),
+ * which should be a constant set in `constants.ts`. Both the
+ * now and timeout arguments should only be used for testing.
+ *
+ * This interface was created to make sure hasTimeoutExceeded()
+ * arguments did not get mixed up since all of them are of
+ * number type.
+ */
+export interface CacheTimeoutData {
+    timestamp: number;
+    now?: number; // current timestamp
+    timeout?: number; // timeout value in milliseconds
+}
+
+/**
+ * Determines if a cache timeout has exceeded.
+ *
+ * By default, the timeout value comes from
+ * `cacheTimeout.default` in `constants.ts`
+ *
+ * @param {CacheTimeoutData} timeoutData
+ * @returns { boolean } - true if timeout has exceeded;
+ * otherwise false.
+ */
+export function hasCacheTimeoutExceeded(timeoutData: CacheTimeoutData): boolean {
+    const now = timeoutData.now || new Date().getTime();
+    const timeout = timeoutData.timeout || cacheTimeout.default;
+    return now - timeoutData.timestamp > timeout;
+}
+
+/**
+ * Determines if a cache timeout has exceeded for group/team
+ * data.
+ *
+ * By default, the timeout value comes from
+ * `cacheTimeout.groups` in `constants.ts`
+ *
+ * @param {CacheTimeoutData} timeoutData
+ * @returns { boolean } - true if timeout has exceeded;
+ * otherwise false.
+ */
+export function hasGroupCacheTimeoutExceeded(timeoutData: CacheTimeoutData): boolean {
+    const timestamp = timeoutData.timestamp;
+    const timeout = cacheTimeout.groups;
+    return hasCacheTimeoutExceeded({timestamp, timeout});
+}

--- a/src/redux/cache/cache.ts
+++ b/src/redux/cache/cache.ts
@@ -1,16 +1,6 @@
-import { CacheTimeoutData, CacheableGroup } from './cache';
-import { Group } from '../../common/model';
+import { CacheTimeoutData } from './cache';
+import { Group, CacheableGroup } from '../../common/model';
 import { cacheTimeout } from './../../common/constants';
-/**
- * Group data to be cached, which includes a
- * timestamp to determine if the cache needs
- * to be refreshed.
- *
- */
-export interface CacheableGroup {
-  group: Group;
-  timestamp: number;
-}
 
 export type GroupCache = CacheableGroup[];
 

--- a/src/redux/cache/cache.ts
+++ b/src/redux/cache/cache.ts
@@ -1,0 +1,46 @@
+import { Group } from '../../common/model';
+
+/**
+ * Group data to be cached, which includes a
+ * timestamp to determine if the cache needs
+ * to be refreshed.
+ *
+ */
+export interface CacheableGroup {
+  group: { [key: string]: Group }; // key is the group id
+  timestamp: number;
+}
+
+export type GroupCache = CacheableGroup[];
+
+/**
+ * The cache for this application with fields
+ * containing the data to be cached.
+ *
+ */
+export class AppCache {
+  groups: GroupCache;
+  constructor(groupCache: GroupCache) {
+      this.groups = groupCache;
+  }
+}
+
+/**
+ * Finds the Group and timestamp in the cache.
+ *
+ * @param {string} id the group's id
+ * @param {AppCache} cache the cache stored in the redux store
+ */
+export function findCacheableGroup(id: string, cache: AppCache): CacheableGroup | undefined {
+    return cache.groups
+        .filter(g => g.group[id])
+        .pop();
+    }
+
+// export function findGroup(id: string, cache: AppCache): Group | undefined {
+//     return findCacheableGroup(id, cache).group[id];
+// }
+
+// export function findGroupTimestamp(id: string, cache: AppCache): number | undefined {
+//     return findCacheableGroup(id, cache).timestamp;
+// }

--- a/src/redux/cache/index.ts
+++ b/src/redux/cache/index.ts
@@ -1,4 +1,4 @@
-export { CacheableGroup, AppCache, addOrReplaceCacheableGroup, findCacheableGroup } from './cache';
+export { AppCache, addOrReplaceCacheableGroup, findCacheableGroup } from './cache';
 export { AppCacheAction, AppCacheActionType, CacheGroupAction, AddToCacheAction } from './action';
 export { cacheGroup, addToCache } from './asyncActionCreator';
 export { appCacheReducer } from './reducer';

--- a/src/redux/cache/index.ts
+++ b/src/redux/cache/index.ts
@@ -1,0 +1,3 @@
+export { CacheableGroup, AppCache } from './cache';
+export { AppCacheAction, AppCacheActionType, CacheGroupAction } from './action';
+export { appCacheReducer } from './reducer';

--- a/src/redux/cache/index.ts
+++ b/src/redux/cache/index.ts
@@ -1,3 +1,4 @@
-export { CacheableGroup, AppCache, addOrReplaceCacheableGroup } from './cache';
+export { CacheableGroup, AppCache, addOrReplaceCacheableGroup, findCacheableGroup } from './cache';
 export { AppCacheAction, AppCacheActionType, CacheGroupAction } from './action';
+export { cacheGroup, addToCache } from './asyncActionCreator';
 export { appCacheReducer } from './reducer';

--- a/src/redux/cache/index.ts
+++ b/src/redux/cache/index.ts
@@ -1,4 +1,4 @@
 export { CacheableGroup, AppCache, addOrReplaceCacheableGroup, findCacheableGroup } from './cache';
-export { AppCacheAction, AppCacheActionType, CacheGroupAction } from './action';
+export { AppCacheAction, AppCacheActionType, CacheGroupAction, AddToCacheAction } from './action';
 export { cacheGroup, addToCache } from './asyncActionCreator';
 export { appCacheReducer } from './reducer';

--- a/src/redux/cache/index.ts
+++ b/src/redux/cache/index.ts
@@ -1,3 +1,3 @@
-export { CacheableGroup, AppCache } from './cache';
+export { CacheableGroup, AppCache, addOrReplaceCacheableGroup } from './cache';
 export { AppCacheAction, AppCacheActionType, CacheGroupAction } from './action';
 export { appCacheReducer } from './reducer';

--- a/src/redux/cache/reducer.test.ts
+++ b/src/redux/cache/reducer.test.ts
@@ -1,0 +1,66 @@
+import { Group } from './../../common/model';
+import { cacheGroup, appCacheReducer, CacheGroupAction,
+  AddToCacheAction, AppCacheActionType, AppCache, CacheableGroup } from './index';
+
+let groups: CacheableGroup[];
+beforeEach(() => {
+  groups = [
+    {
+        group: { id: 'craig', name: 'Group Craig', description: 'Craig codes',
+          subtitle: 'worker bee', photoURL: '', totalCalls: 10 } ,
+        timestamp: 1000
+    },
+    {
+        group: { id: 'jeremy', name: 'Group Jeremy', description: 'Jeremy advises',
+          subtitle: 'wise guy', photoURL: '', totalCalls: 100 } ,
+        timestamp: 10000
+    },
+    {
+        group: { id: 'nick', name: 'Group Nick', description: 'Nick rules!!!' ,
+          subtitle: 'the best', photoURL: '', totalCalls: 1000 } ,
+        timestamp: 100000
+    }
+  ];
+});
+
+test('appCacheReducer() processes CACHE_GROUP action correctly by modifying timestamp of an existing record', () => {
+  const cgroup: CacheableGroup = { group: { id: 'nick', name: 'Group Nick', description: 'Nick rules!!!' ,
+    subtitle: 'the best', photoURL: '', totalCalls: 1000 }, timestamp: 100000 } ;
+  const state: AppCache = new AppCache(groups);
+  const action: CacheGroupAction = {
+    type: AppCacheActionType.CACHE_GROUP,
+    payload: cgroup
+  };
+  const newState = appCacheReducer(state, action);
+  expect(newState.groups.length).toEqual(3);
+  // timestamp will be changed to current time
+  expect(newState.groups[2].timestamp).not.toEqual(groups[2].timestamp);
+});
+
+test('appCacheReducer() processes CACHE_GROUP action correctly by adding a new group to the cache', () => {
+  const cgroup: CacheableGroup = { group: { id: 'rebecca', name: 'Group Rebecca', description: 'Rebecca runs the show' ,
+    subtitle: 'boss person', photoURL: '', totalCalls: 1000 }, timestamp: 0 } ;
+  const state: AppCache = new AppCache(groups);
+  const action: CacheGroupAction = {
+    type: AppCacheActionType.CACHE_GROUP,
+    payload: cgroup
+  };
+  const newState = appCacheReducer(state, action);
+  // Cache should contain an additional new group
+  expect(newState.groups.length).toEqual(4);
+  expect(newState.groups[3].group.id).toEqual('rebecca');
+});
+
+test('appCacheReducer() processes ADD_GROUP_TO_CACHE action correctly', () => {
+  const group: Group = { id: 'rebecca', name: 'Group Rebecca', description: 'Rebecca runs the show' ,
+    subtitle: 'boss person', photoURL: '', totalCalls: 1000 } ;
+  const state: AppCache = new AppCache(groups);
+  const action: AddToCacheAction = {
+    type: AppCacheActionType.ADD_GROUP_TO_CACHE,
+    payload: group
+  };
+  const newState = appCacheReducer(state, action);
+  // Cache should contain an additional group
+  expect(newState.groups.length).toEqual(4);
+  expect(newState.groups[3].group.id).toEqual('rebecca');
+});

--- a/src/redux/cache/reducer.test.ts
+++ b/src/redux/cache/reducer.test.ts
@@ -1,5 +1,5 @@
 import { Group } from './../../common/model';
-import { cacheGroup, appCacheReducer, CacheGroupAction,
+import { appCacheReducer, CacheGroupAction,
   AddToCacheAction, AppCacheActionType, AppCache, CacheableGroup } from './index';
 
 let groups: CacheableGroup[];

--- a/src/redux/cache/reducer.test.ts
+++ b/src/redux/cache/reducer.test.ts
@@ -1,6 +1,6 @@
-import { Group } from './../../common/model';
+import { Group, CacheableGroup } from './../../common/model';
 import { appCacheReducer, CacheGroupAction,
-  AddToCacheAction, AppCacheActionType, AppCache, CacheableGroup } from './index';
+  AddToCacheAction, AppCacheActionType, AppCache } from './index';
 
 let groups: CacheableGroup[];
 beforeEach(() => {

--- a/src/redux/cache/reducer.ts
+++ b/src/redux/cache/reducer.ts
@@ -15,13 +15,11 @@ export const appCacheReducer: Reducer<AppCache> = (
         const cgroup = action.payload as CacheableGroup;
         const group = cgroup.group;
         const newGroups = addOrReplaceCacheableGroup(groups, group);
-        console.log('CACHE_GROUP action', newGroups);
         return { ...state, groups: newGroups };
       case AppCacheActionType.ADD_GROUP_TO_CACHE:
         const groups1 = state.groups;
         const group1 = action.payload as Group;
         const newGroups1 = addOrReplaceCacheableGroup(groups1, group1);
-        console.log('ADD_GROUP_TO_CACHE action', newGroups1);
         return { ...state, groups: newGroups1 };
       default:
         return state;

--- a/src/redux/cache/reducer.ts
+++ b/src/redux/cache/reducer.ts
@@ -1,12 +1,22 @@
 import { Reducer } from 'redux';
-import { AppCache, AppCacheAction } from './';
+import {
+  CacheableGroup, AppCache,
+  AppCacheAction, AppCacheActionType,
+  addOrReplaceCacheableGroup } from './';
 
 export const appCacheReducer: Reducer<AppCache> = (
-  state: AppCache = {} as AppCache,
+  state: AppCache = {groups: []} as AppCache,
   action: AppCacheAction): AppCache => {
 
     switch (action.type) {
+      case AppCacheActionType.CACHE_GROUP:
+        const groups = state.groups;
+        const cgroup = action.payload as CacheableGroup;
+        const group = cgroup.group;
+        const newGroups = addOrReplaceCacheableGroup(groups, group);
 
-      default: return state;
+        return { ...state, groups: newGroups };
+      default:
+        return state;
     }
 };

--- a/src/redux/cache/reducer.ts
+++ b/src/redux/cache/reducer.ts
@@ -1,9 +1,8 @@
 import { Reducer } from 'redux';
 import {
-  CacheableGroup, AppCache,
-  AppCacheAction, AppCacheActionType,
+  AppCache, AppCacheAction, AppCacheActionType,
   addOrReplaceCacheableGroup } from './';
-import { Group } from '../../common/model';
+import { Group, CacheableGroup } from '../../common/model';
 
 export const appCacheReducer: Reducer<AppCache> = (
   state: AppCache = {groups: []} as AppCache,

--- a/src/redux/cache/reducer.ts
+++ b/src/redux/cache/reducer.ts
@@ -1,0 +1,12 @@
+import { Reducer } from 'redux';
+import { AppCache, AppCacheAction } from './';
+
+export const appCacheReducer: Reducer<AppCache> = (
+  state: AppCache = {} as AppCache,
+  action: AppCacheAction): AppCache => {
+
+    switch (action.type) {
+
+      default: return state;
+    }
+};

--- a/src/redux/cache/reducer.ts
+++ b/src/redux/cache/reducer.ts
@@ -3,6 +3,7 @@ import {
   CacheableGroup, AppCache,
   AppCacheAction, AppCacheActionType,
   addOrReplaceCacheableGroup } from './';
+import { Group } from '../../common/model';
 
 export const appCacheReducer: Reducer<AppCache> = (
   state: AppCache = {groups: []} as AppCache,
@@ -14,8 +15,14 @@ export const appCacheReducer: Reducer<AppCache> = (
         const cgroup = action.payload as CacheableGroup;
         const group = cgroup.group;
         const newGroups = addOrReplaceCacheableGroup(groups, group);
-
+        console.log('CACHE_GROUP action', newGroups);
         return { ...state, groups: newGroups };
+      case AppCacheActionType.ADD_GROUP_TO_CACHE:
+        const groups1 = state.groups;
+        const group1 = action.payload as Group;
+        const newGroups1 = addOrReplaceCacheableGroup(groups1, group1);
+        console.log('ADD_GROUP_TO_CACHE action', newGroups1);
+        return { ...state, groups: newGroups1 };
       default:
         return state;
     }

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -45,8 +45,8 @@ export const getGroupIssuesIfNeeded = (groupid: string) => {
     // This method is primarily for when a user has navigated
     // directly to a route with an issue id
     if (!state.remoteDataState.groupIssues || state.remoteDataState.groupIssues.length === 0 ||
-        state.remoteDataState.currentGroup !== groupid) {
-        
+        state.remoteDataState.currentGroupId !== groupid) {
+
       const loc = state.locationState.address;
       if (loc) {
         dispatch(fetchGroupIssues(groupid, loc));
@@ -223,10 +223,10 @@ export const startup = () => {
         }
     }
     window.history.replaceState(null, '', window.location.pathname);
-    
+
     const state = getState();
     const loc = state.locationState.address;
-    
+
     if (loc) {
       // console.log('Using cached address');
       dispatch(fetchAllIssues(loc))

--- a/src/redux/remoteData/reducer.ts
+++ b/src/redux/remoteData/reducer.ts
@@ -5,7 +5,7 @@ import { RemoteDataAction, RemoteDataActionType } from './index';
 export interface RemoteDataState {
   issues: Issue[];
   inactiveIssues: Issue[];
-  currentGroup: string;
+  currentGroupId: string;
   groupIssues: Issue[];
   callTotal: number;
   donations: Donations;

--- a/src/redux/root.ts
+++ b/src/redux/root.ts
@@ -1,10 +1,11 @@
 import { ApplicationState } from './root';
 import { routerReducer, RouterState } from 'react-router-redux';
 import { Reducer, combineReducers } from 'redux';
-import { LocationState, locationStateReducer } from './location/reducer';
-import { CallState, callStateReducer } from './callState/reducer';
-import { RemoteDataState, remoteDataReducer } from './remoteData/reducer';
-import { UserStatsState, userStatsReducer } from './userStats/reducer';
+import { LocationState, locationStateReducer } from './location';
+import { CallState, callStateReducer } from './callState';
+import { RemoteDataState, remoteDataReducer } from './remoteData';
+import { UserStatsState, userStatsReducer } from './userStats';
+import { AppCache, appCacheReducer } from './cache';
 
 export enum OutcomeType {
   UNAVAILABLE = 'unavailable',
@@ -18,6 +19,7 @@ export interface ApplicationState {
   callState: CallState;
   locationState: LocationState;
   userStatsState: UserStatsState;
+  appCache: AppCache;
 }
 
 export const DefaultApplicationState: ApplicationState = {
@@ -25,6 +27,7 @@ export const DefaultApplicationState: ApplicationState = {
   callState: {} as CallState,
   locationState: {} as LocationState,
   userStatsState: {} as UserStatsState,
+  appCache: {} as AppCache
 };
 
 // DANGER: TypeScript magic ahead!!
@@ -45,6 +48,7 @@ export const ApplicationStateKey: ApplicationStateKeyTypes = {
   remoteDataState: 'remoteDataState',
   callState: 'callState',
   userStatsState: 'userStatsState',
+  appCache: 'appCache'
 };
 
 const rootReducer = combineReducers({
@@ -53,6 +57,7 @@ const rootReducer = combineReducers({
   callState: callStateReducer,
   locationState: locationStateReducer,
   userStatsState: userStatsReducer,
+  appCacheReducer: appCacheReducer
 });
 
 export default rootReducer;

--- a/src/redux/root.ts
+++ b/src/redux/root.ts
@@ -57,7 +57,7 @@ const rootReducer = combineReducers({
   callState: callStateReducer,
   locationState: locationStateReducer,
   userStatsState: userStatsReducer,
-  appCacheReducer: appCacheReducer
+  appCache: appCacheReducer
 });
 
 export default rootReducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -41,7 +41,8 @@ export default (initialState) => {
   const localPersistKeys: ApplicationStateKeyType[] = [
     ApplicationStateKey.locationState,
     ApplicationStateKey.userStatsState,
-    ApplicationStateKey.callState
+    ApplicationStateKey.callState,
+    ApplicationStateKey.appCache
   ];
   persistor = persistStore(
     store,


### PR DESCRIPTION
This PR implements an application cache key in the Redux store to hold group/team data that is persisted using `redux-persist`. It is an implementation of issue #367.