### PR TITLE
Small team improvements

### DIFF
--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -65,6 +65,23 @@ export class Call extends React.Component<Props, State> {
     this.setState(this.setStateFromProps(newProps));
   }
 
+  // this should obviously be somewhere on issue but as an interface and not a class I don't know where...
+  // split district as we define it now applies to house reps, not state level. This helps us ignore it if
+  // reps are only Senate or only State level
+  hasHouseReps(issue: Issue | undefined): boolean {
+    let hasHouseRep = false;
+
+    if (issue && issue.contacts) {
+      issue.contacts.forEach(contact => {
+        if (contact.area === 'US House') {
+          hasHouseRep = true;
+        }
+      });
+    }
+
+    return hasHouseRep;
+  }
+
   render() {
     return (
       <section className="call">
@@ -72,7 +89,7 @@ export class Call extends React.Component<Props, State> {
           currentIssue={this.state.issue}
           t={i18n.t}
         />
-        {this.props.locationState.splitDistrict ?
+        {this.props.locationState.splitDistrict && this.hasHouseReps(this.props.issue) ?
         <NoContactSplitDistrict
           splitDistrict={this.props.locationState.splitDistrict}
           clearLocation={this.props.clearLocation}
@@ -92,7 +109,7 @@ export class Call extends React.Component<Props, State> {
           locationState={this.props.locationState}
           t={i18n.t}
         />
-        {this.props.locationState.splitDistrict || 
+        {(this.props.locationState.splitDistrict && this.hasHouseReps(this.props.issue)) || 
          this.props.issue && 
          (this.props.issue.contacts && this.props.issue.contacts.length === 0) ? <span/> :
         <Outcomes

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -123,6 +123,11 @@ class CallPage extends React.Component<Props, State> {
 
   getView() {
     const currentGroup = this.props.currentGroup ? this.props.currentGroup : undefined;
+    let groupImage = '/img/5calls-stars.png';
+    if (currentGroup && currentGroup.group.photoURL) {
+      groupImage = currentGroup.group.photoURL;
+    }
+    
     if (this.props.currentIssue &&
         this.props.currentIssue.contactType &&
         this.props.currentIssue.contactType === 'FETCH') {
@@ -132,6 +137,24 @@ class CallPage extends React.Component<Props, State> {
           issueId={this.props.currentIssue ? this.props.currentIssue.id : undefined}
           currentGroup={currentGroup}
         >
+          { currentGroup ? 
+          <div className="page__group">
+            <div className="page__header">
+              <div className="page__header__image"><img alt={currentGroup.group.name} src={groupImage}/></div>
+              <h1 className="page__title">{currentGroup.group.name}</h1>
+              <h2 className="page__subtitle">{currentGroup.group.subtitle}&nbsp;</h2>
+            </div>
+            <FetchCall
+              issue={this.props.currentIssue}
+              currentGroup={currentGroup}
+              callState={this.props.callState}
+              locationState={this.props.locationState}
+              clearLocation={this.props.clearLocation}
+              onSubmitOutcome={this.props.onSubmitOutcome}
+              t={i18n.t}
+            />
+          </div>
+          :
           <FetchCall
             issue={this.props.currentIssue}
             currentGroup={currentGroup}
@@ -141,6 +164,7 @@ class CallPage extends React.Component<Props, State> {
             onSubmitOutcome={this.props.onSubmitOutcome}
             t={i18n.t}
           />
+          }
         </LayoutContainer>
       );
     } else {
@@ -158,6 +182,23 @@ class CallPage extends React.Component<Props, State> {
               '5 Calls: Make your voice heard'}
             </title>
           </Helmet>
+          { currentGroup ? 
+          <div className="page__group">
+            <div className="page__header">
+              <div className="page__header__image"><img alt={currentGroup.group.name} src={groupImage}/></div>
+              <h1 className="page__title">{currentGroup.group.name}</h1>
+              <h2 className="page__subtitle">{currentGroup.group.subtitle}&nbsp;</h2>
+            </div>
+            <CallTranslatable
+              issue={this.props.currentIssue}
+              callState={this.props.callState}
+              locationState={this.props.locationState}
+              clearLocation={this.props.clearLocation}
+              onSubmitOutcome={this.props.onSubmitOutcome}
+              t={i18n.t}
+            />
+          </div>
+          :
           <CallTranslatable
             issue={this.props.currentIssue}
             callState={this.props.callState}
@@ -166,6 +207,7 @@ class CallPage extends React.Component<Props, State> {
             onSubmitOutcome={this.props.onSubmitOutcome}
             t={i18n.t}
           />
+          }
         </LayoutContainer>
       );
     }

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -22,7 +22,7 @@ interface Props extends RouteProps {
   readonly setLocation: (location: string) => void;
   readonly clearLocation: () => void;
   readonly onSelectIssue: (issueId: string) => Function;
-  readonly onGetIssuesIfNeeded: (groupid: string) => Function;
+  readonly onGetIssuesIfNeeded: () => Function;
   readonly onJoinGroup: (group: Group) => Function;
   readonly currentGroup?: CacheableGroup;
   readonly cacheGroup: (group: Group) => Function;
@@ -70,7 +70,7 @@ class GroupPage extends React.Component<Props, State> {
           }
           // Dispatch call to add to cache
           this.props.cacheGroup(group);
-          this.props.onGetIssuesIfNeeded(group.id);
+          this.props.onGetIssuesIfNeeded();
         })
         .catch((error: Error) =>  {
           // If 404 error, set loading state to NOTFOUND
@@ -87,11 +87,14 @@ class GroupPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
+    if (!this.props.issues) {
+      queueUntilRehydration(() => {
+        this.props.onGetIssuesIfNeeded();
+      });
+    }
+
     if (this.state.pageGroupState) {
       this.setState({loadingState: GroupLoadingState.FOUND});
-      queueUntilRehydration(() => {
-        this.props.onGetIssuesIfNeeded(this.props.match.params.groupid);
-      });
     } else {
       this.setState({loadingState: GroupLoadingState.LOADING});
     }

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -23,7 +23,7 @@ interface StateProps {
 
 interface DispatchProps {
   readonly onSelectIssue: (issueId: string) => void;
-  readonly onGetIssuesIfNeeded: (groupid: string) => void;
+  readonly onGetIssuesIfNeeded: () => void;
   readonly onJoinGroup: (group: Group) => void;
   readonly cacheGroup: (group: Group) => Function;
 }
@@ -50,11 +50,18 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   };
 };
 
-const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>): DispatchProps => {
+const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>, ownProps: OwnProps): DispatchProps => {
   return bindActionCreators(
     {
       onSelectIssue: selectIssueActionCreator,
-      onGetIssuesIfNeeded: getGroupIssuesIfNeeded,
+      onGetIssuesIfNeeded: () => {
+        return (nextDispatch: Dispatch<ApplicationState>,
+                getState: () => ApplicationState) => {
+          // this page knows about the path params, and sub-components may not,
+          // attach the groupid to this method here
+          dispatch(getGroupIssuesIfNeeded(ownProps.match.params.groupid));
+        };
+      },
       onJoinGroup: joinGroupActionCreator,
       cacheGroup: addToCache
     },

--- a/src/components/layout/LayoutContainer.tsx
+++ b/src/components/layout/LayoutContainer.tsx
@@ -41,8 +41,13 @@ function mapStateToProps(state: ApplicationState, ownProps: OwnProps): StateProp
   }
 
   let issues: Issue[] = [];
-  // overrise issues from above the layout container if needed
-  issues = ownProps.issues ? ownProps.issues : state.remoteDataState.issues;
+  // overrise issues from above the layout container if needed and not on a group page
+  // group pages will load issues themselves, and shouldn't default to normal issues
+  if (ownProps.currentGroup) {
+    issues = ownProps.issues ? ownProps.issues : [];
+  } else {
+    issues = ownProps.issues ? ownProps.issues : state.remoteDataState.issues;
+  }
 
   return {
     issues: issues,

--- a/src/redux/remoteData/asyncActionCreator.ts
+++ b/src/redux/remoteData/asyncActionCreator.ts
@@ -46,7 +46,6 @@ export const getGroupIssuesIfNeeded = (groupid: string) => {
     // directly to a route with an issue id
     if (!state.remoteDataState.groupIssues || state.remoteDataState.groupIssues.length === 0 ||
         state.remoteDataState.currentGroupId !== groupid) {
-
       const loc = state.locationState.address;
       if (loc) {
         dispatch(fetchGroupIssues(groupid, loc));
@@ -228,11 +227,10 @@ export const startup = () => {
     const loc = state.locationState.address;
 
     if (loc) {
-      // console.log('Using cached address');
       dispatch(fetchAllIssues(loc))
-        .then(() => {
-          setLocationFetchType(LocationFetchType.CACHED_ADDRESS);
-        });
+      .then(() => {
+        setLocationFetchType(LocationFetchType.CACHED_ADDRESS);
+      });
     } else {
       dispatch(fetchBrowserGeolocation());
     }


### PR DESCRIPTION
Added the team header to team call pages, improved the team issue loading so it doesn't flash 5 calls issues (as much, still some improvements to make here) and resolved an issue where split districts would show even if you had no house reps in an issue.  