### PR TITLE
Member browses to a group page without appCache and locationState in storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+*.diff

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -8,8 +8,8 @@ import { getIssue } from '../shared/utils';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState, clearAddress } from '../../redux/location';
 import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
-import { findCacheableGroup, cacheGroup } from '../../redux/cache';
-import { GroupLoadingActionStatus } from '../../redux/group';
+import { findCacheableGroup } from '../../redux/cache';
+import { updateGroup } from '../../redux/group';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -82,18 +82,7 @@ const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>, ownProps: OwnP
         };
       },
       clearLocation: clearAddress,
-      cacheGroup: (group) => {
-        return (
-          nextDispatch: Dispatch<ApplicationState>,
-          getState: () => ApplicationState) => {
-            const state = getState();
-            // test whether group.name is set and
-            // whether timeout has exceeded
-            if (state.groupState.groupLoadingStatus === GroupLoadingActionStatus.LOADING) {
-              dispatch(cacheGroup(group.id));
-            }
-        };
-      }
+      cacheGroup: updateGroup
     },
     dispatch);
 };

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -77,10 +77,17 @@ class GroupPage extends React.Component<Props, State> {
         this.props.cacheGroup(group);
       });
     }
+
+    if (!this.props.issues || this.props.issues.length === 0) {
+      queueUntilRehydration(() => {
+        this.props.onGetIssuesIfNeeded();
+      });
+    }
+
   }
 
   componentDidMount() {
-    if (!this.props.issues) {
+    if (!this.props.issues || this.props.issues.length === 0) {
       queueUntilRehydration(() => {
         this.props.onGetIssuesIfNeeded();
       });

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -41,7 +41,10 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   let groupPageIssues: Issue[] = [];
 
   // send group issues if they exist, normal active ones if they don't
-  if (state.remoteDataState.groupIssues && state.remoteDataState.groupIssues.length !== 0) {
+  if (state.remoteDataState.groupIssues &&
+    state.remoteDataState.groupIssues.length !== 0 &&
+    currentGroup.customCalls
+  ) {
     groupPageIssues = state.remoteDataState.groupIssues;
   } else {
     groupPageIssues = state.remoteDataState.issues;


### PR DESCRIPTION
Fix of issue #385 with a group/team member visiting a team page and not having `appCache` and `locationState` in local storage.

Done:
Member browses to team home page without `appCache` and `locationState` in local storage.

To Do:
Member browses to team issue URL without `appCache` and `locationState` in local storage.
