### PR TITLE
New team member browses to a group page without appCache and locationState in storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+*.diff

--- a/src/components/call/CallPage.test.tsx
+++ b/src/components/call/CallPage.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+import { History, Location } from 'history';
+import i18n from '../../services/i18n';
+import { I18nextProvider } from 'react-i18next';
+import { CallPage } from './index';
+import { Issue, DefaultIssue, Group, getDefaultGroup } from '../../common/model';
+import { CallState } from '../../redux/callState';
+import { LocationState } from 'history';
+
+test('snapshot should render correctly with an issue and group', () => {
+  const id = 'craig';
+  const group: Group = getDefaultGroup(id);
+  const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName' });
+  const pageProps = initPage(group);
+  pageProps.currentIssue = issue;
+  pageProps.issues = [issue];
+  pageProps.match.params.issueid = issue.id;
+  const component = shallow(
+    <I18nextProvider i18n={i18n} >
+      <CallPage
+        {...pageProps}
+      />
+    </I18nextProvider>
+  );
+  expect(component).toMatchSnapshot();
+});
+
+test('snapshot should render correctly with an issue and NO group', () => {
+  const issue: Issue = Object.assign({}, DefaultIssue, { id: '1', name: 'testName' });
+  const pageProps = initPage();
+  pageProps.currentIssue = issue;
+  pageProps.issues = [issue];
+  pageProps.match.params.issueid = issue.id;
+  const component = shallow(
+    <I18nextProvider i18n={i18n} >
+      <CallPage
+        {...pageProps}
+      />
+    </I18nextProvider>
+  );
+  expect(component).toMatchSnapshot();
+});
+
+const initPage = (group?: Group) => {
+  return {
+    match: {params: {groupid: group ? group.id : undefined, issueid: '100'}, isExact: true, path: '', url: ''},
+    location: {} as Location,
+    history: {} as History,
+    issues: [] as Issue[],
+    currentIssue: {} as Issue,
+    currentGroup: group,
+    callState: {} as CallState,
+    locationState: {} as LocationState,
+    onSubmitOutcome: jest.fn(),
+    onSelectIssue: jest.fn(),
+    onGetIssuesIfNeeded: jest.fn(),
+    clearLocation: jest.fn(),
+    cacheGroup: jest.fn(),
+    hasBeenCached: false,
+  };
+};

--- a/src/components/call/CallPage.tsx
+++ b/src/components/call/CallPage.tsx
@@ -114,8 +114,13 @@ class CallPage extends React.Component<Props, State> {
     if (this.props.currentGroup
       && newProps.currentGroup &&
       this.props.currentGroup.id !== newProps.currentGroup.id) {
-        // console.log('CallPage Resetting hasBeenCached');
         this.setState({...this.state, hasBeenCached: false});
+    }
+
+    if (!this.props.issues) {
+      queueUntilRehydration(() => {
+        this.props.onGetIssuesIfNeeded();
+      });
     }
 
     if (!this.state.hasBeenCached && newProps.currentGroup) {
@@ -131,18 +136,9 @@ class CallPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    if (!this.props.issues) {
-      // On the first render, if the issues haven't been loaded(came here directly, not first to home page)
-      // here we'll check to see if issues are in the redux store and if not we'll load them
-      // if we have to load them, the component will be re-rendered after the issues are retrieved
-      queueUntilRehydration(() => {
-        this.props.onGetIssuesIfNeeded();
-      });
-    } else {
-      // this is the case where the user has clicked on an issue from the sidebar
-      if (!this.props.callState.currentIssueId && this.props.currentIssue) {
-        this.props.onSelectIssue(this.props.currentIssue.id);
-      }
+    // the user has clicked on an issue from the sidebar
+    if (!this.props.callState.currentIssueId && this.props.currentIssue) {
+      this.props.onSelectIssue(this.props.currentIssue.id);
     }
   }
 

--- a/src/components/call/__snapshots__/CallPage.test.tsx.snap
+++ b/src/components/call/__snapshots__/CallPage.test.tsx.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot should render correctly with an issue and NO group 1`] = `
+<CallPage
+  cacheGroup={[Function]}
+  callState={Object {}}
+  clearLocation={[Function]}
+  currentIssue={
+    Object {
+      "categories": Array [],
+      "id": "1",
+      "inactive": false,
+      "link": "",
+      "linkTitle": "",
+      "name": "testName",
+      "outcomeModels": Array [],
+      "reason": "",
+      "script": "",
+      "slug": "",
+    }
+  }
+  hasBeenCached={false}
+  history={Object {}}
+  issues={
+    Array [
+      Object {
+        "categories": Array [],
+        "id": "1",
+        "inactive": false,
+        "link": "",
+        "linkTitle": "",
+        "name": "testName",
+        "outcomeModels": Array [],
+        "reason": "",
+        "script": "",
+        "slug": "",
+      },
+    ]
+  }
+  location={Object {}}
+  locationState={Object {}}
+  match={
+    Object {
+      "isExact": true,
+      "params": Object {
+        "groupid": undefined,
+        "issueid": "1",
+      },
+      "path": "",
+      "url": "",
+    }
+  }
+  onGetIssuesIfNeeded={[Function]}
+  onSelectIssue={[Function]}
+  onSubmitOutcome={[Function]}
+/>
+`;
+
+exports[`snapshot should render correctly with an issue and group 1`] = `
+<CallPage
+  cacheGroup={[Function]}
+  callState={Object {}}
+  clearLocation={[Function]}
+  currentGroup={
+    Object {
+      "customCalls": false,
+      "description": "",
+      "id": "craig",
+      "name": "",
+      "photoURL": "",
+      "subtitle": "",
+      "totalCalls": 0,
+    }
+  }
+  currentIssue={
+    Object {
+      "categories": Array [],
+      "id": "1",
+      "inactive": false,
+      "link": "",
+      "linkTitle": "",
+      "name": "testName",
+      "outcomeModels": Array [],
+      "reason": "",
+      "script": "",
+      "slug": "",
+    }
+  }
+  hasBeenCached={false}
+  history={Object {}}
+  issues={
+    Array [
+      Object {
+        "categories": Array [],
+        "id": "1",
+        "inactive": false,
+        "link": "",
+        "linkTitle": "",
+        "name": "testName",
+        "outcomeModels": Array [],
+        "reason": "",
+        "script": "",
+        "slug": "",
+      },
+    ]
+  }
+  location={Object {}}
+  locationState={Object {}}
+  match={
+    Object {
+      "isExact": true,
+      "params": Object {
+        "groupid": "craig",
+        "issueid": "1",
+      },
+      "path": "",
+      "url": "",
+    }
+  }
+  onGetIssuesIfNeeded={[Function]}
+  onSelectIssue={[Function]}
+  onSubmitOutcome={[Function]}
+/>
+`;

--- a/src/components/groups/GroupCallPageContainer.tsx
+++ b/src/components/groups/GroupCallPageContainer.tsx
@@ -8,8 +8,8 @@ import { getIssue } from '../shared/utils';
 import { getGroupIssuesIfNeeded } from '../../redux/remoteData';
 import { LocationState, clearAddress } from '../../redux/location';
 import { CallState, OutcomeData, submitOutcome, selectIssueActionCreator } from '../../redux/callState';
-import { findCacheableGroup, cacheGroup } from '../../redux/cache';
-import { GroupLoadingActionStatus } from '../../redux/group';
+import { findCacheableGroup } from '../../redux/cache';
+import { updateGroup } from '../../redux/group';
 
 interface OwnProps extends RouteComponentProps<{ groupid: string, issueid: string }> { }
 
@@ -82,18 +82,7 @@ const mapDispatchToProps = (dispatch: Dispatch<ApplicationState>, ownProps: OwnP
         };
       },
       clearLocation: clearAddress,
-      cacheGroup: (group) => {
-        return (
-          nextDispatch: Dispatch<ApplicationState>,
-          getState: () => ApplicationState) => {
-            const state = getState();
-            // test whether group.name is set and
-            // whether timeout has exceeded
-            if (state.groupState.groupLoadingStatus === GroupLoadingActionStatus.LOADING) {
-              dispatch(cacheGroup(group.id));
-            }
-        };
-      }
+      cacheGroup: updateGroup
     },
     dispatch);
 };

--- a/src/components/groups/GroupPage.tsx
+++ b/src/components/groups/GroupPage.tsx
@@ -77,10 +77,17 @@ class GroupPage extends React.Component<Props, State> {
         this.props.cacheGroup(group);
       });
     }
+
+    if (!this.props.issues || this.props.issues.length === 0) {
+      queueUntilRehydration(() => {
+        this.props.onGetIssuesIfNeeded();
+      });
+    }
+
   }
 
   componentDidMount() {
-    if (!this.props.issues) {
+    if (!this.props.issues || this.props.issues.length === 0) {
       queueUntilRehydration(() => {
         this.props.onGetIssuesIfNeeded();
       });

--- a/src/components/groups/GroupPageContainer.tsx
+++ b/src/components/groups/GroupPageContainer.tsx
@@ -41,7 +41,10 @@ const mapStateToProps = (state: ApplicationState, ownProps: OwnProps): StateProp
   let groupPageIssues: Issue[] = [];
 
   // send group issues if they exist, normal active ones if they don't
-  if (state.remoteDataState.groupIssues && state.remoteDataState.groupIssues.length !== 0) {
+  if (state.remoteDataState.groupIssues &&
+    state.remoteDataState.groupIssues.length !== 0 &&
+    currentGroup.customCalls
+  ) {
     groupPageIssues = state.remoteDataState.groupIssues;
   } else {
     groupPageIssues = state.remoteDataState.issues;


### PR DESCRIPTION
There was a problem reported in issue #385 when a new team member browses to a team home page, they would just get the team page with the 5 Calls issues in the sidebar. If the team member browses to a URL of a team issue, they would get a Not Found message in the center of the page with only 5 Calls issues in the sidebar.

WIth this PR, when a new user browses to a team home page, the issues for that team are displayed in the sidebar with the team page in page center and when a new user browses to a team issue URL, the team issues are displayed in the sidebar and the issue being browsed in the page center.

The problem reported in issue #385 was the result of the team member not yet having `locationState` in local storage and  group/team data in local storage `appCache`. This PR assures that location state and group data are retrieved if they are missing.

This PR replaces #386 