### PR TITLE
Issue 395: Ensure state legislators are addressed correctly

### DIFF
--- a/src/components/call/Script.test.tsx
+++ b/src/components/call/Script.test.tsx
@@ -112,6 +112,8 @@ describe('getContactNameWithTitle', () => {
         expect(agTitle).toBe('Attorney General Betty White');
         const legTitle = getContactNameWithTitle(contacts, 3);
         expect(legTitle).toBe('Legislator Luna Lovegood');
+    });
+    it('returns just the name of the contact when the title is unknown', () => {
         const unknownTitle = getContactNameWithTitle(contacts, 4);
         expect(unknownTitle).toBe('Lisbeth Salander');
     });

--- a/src/components/call/Script.test.tsx
+++ b/src/components/call/Script.test.tsx
@@ -3,6 +3,7 @@ import * as ReactMarkdown from 'react-markdown';
 import { shallow } from 'enzyme';
 import i18n from '../../services/i18n';
 import { Script } from './';
+import { getContactNameWithTitle } from './Script';
 import { Contact, Issue, DefaultIssue, LocationUiState, LocationFetchType } from '../../common/model';
 import { LocationState } from '../../redux/location';
 
@@ -57,5 +58,61 @@ describe('when the script text is shown', () => {
             <Script issue={issue} contactIndex={0} locationState={locationState} t={t} />
         );
         expect(wrapper.contains(<ReactMarkdown source="script_text" />)).toBe(true);
+    });
+});
+
+describe('getContactNameWithTitle', () => {
+    const contacts: Contact[] = [{
+        id: '293',
+        area: 'House',
+        name: 'Googly Moogly',
+        phone: '',
+        state: '',
+        party: '',
+        reason: ''
+    }, {
+        id: '666',
+        area: 'Senate',
+        name: 'Damian Longhoof',
+        phone: '',
+        state: '',
+        party: '',
+        reason: ''
+    }, {
+        id: '123',
+        area: 'AttorneyGeneral',
+        name: 'Betty White',
+        phone: '',
+        state: '',
+        party: '',
+        reason: ''
+    }, {
+        id: '789',
+        area: 'StateLower',
+        name: 'Luna Lovegood',
+        phone: '',
+        state: '',
+        party: '',
+        reason: ''
+    }, {
+        id: '739',
+        area: 'Underground',
+        name: 'Lisbeth Salander',
+        phone: '',
+        state: '',
+        party: '',
+        reason: ''
+    }];
+    it('returns the name of the contact with their title', () => {
+        const repTitle = getContactNameWithTitle(contacts, 0);
+        expect(repTitle).toBe('Rep. Googly Moogly');
+        const senateTitle = getContactNameWithTitle(contacts, 1);
+        expect(senateTitle).toBe('Senator Damian Longhoof');
+        const agTitle = getContactNameWithTitle(contacts, 2);
+        expect(agTitle).toBe('Attorney General Betty White');
+        const legTitle = getContactNameWithTitle(contacts, 3);
+        expect(legTitle).toBe('Legislator Luna Lovegood');
+        const unknownTitle = getContactNameWithTitle(contacts, 4);
+        expect(unknownTitle).toBe('Lisbeth Salander');
     });
 });

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -18,7 +18,19 @@ const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
 function getContactNameWithTitle(contacts: Contact[], contactIndex: number) {
   const currentContact = contacts[contactIndex];
-  const title = currentContact.area === 'House' ? 'Rep. ' : 'Senator ';
+  let title = 'Legislator ';
+  switch (currentContact.area) {
+    case 'House':
+    case 'StateLower':
+      title = 'Rep. ';
+      break;
+    case 'Senate':
+    case 'StateUpper':
+      title = 'Senator ';
+      break;
+    default:
+      title = 'Legislator ';
+  }
   return title + currentContact.name;
 }
 

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -76,3 +76,5 @@ export const Script: React.StatelessComponent<Props> = ({ issue, contactIndex = 
 };
 
 export const ScriptTranslatable = translate()(Script);
+
+export { getContactNameWithTitle };

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -21,12 +21,14 @@ function getContactNameWithTitle(contacts: Contact[], contactIndex: number) {
   let title = '';
   switch (currentContact.area) {
     case 'House':
-    case 'StateLower':
       title = 'Rep. ';
       break;
     case 'Senate':
-    case 'StateUpper':
       title = 'Senator ';
+      break;
+    case 'StateLower':
+    case 'StateUpper':
+      title = 'Legislator ';
       break;
     default:
       title = '';

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -18,7 +18,7 @@ const locationReg = /\[CITY,\s?ZIP\]|\[CITY,\s?STATE\]/gi;
 
 function getContactNameWithTitle(contacts: Contact[], contactIndex: number) {
   const currentContact = contacts[contactIndex];
-  let title = 'Legislator ';
+  let title = '';
   switch (currentContact.area) {
     case 'House':
     case 'StateLower':
@@ -29,7 +29,7 @@ function getContactNameWithTitle(contacts: Contact[], contactIndex: number) {
       title = 'Senator ';
       break;
     default:
-      title = 'Legislator ';
+      title = '';
   }
   return title + currentContact.name;
 }

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -30,6 +30,15 @@ function getContactNameWithTitle(contacts: Contact[], contactIndex: number) {
     case 'StateUpper':
       title = 'Legislator ';
       break;
+    case 'Governor':
+      title = 'Governor ';
+      break;
+    case 'AttorneyGeneral':
+      title = 'Attorney General ';
+      break; 
+    case 'SecretaryOfState':
+      title = 'Secretary of State ';
+      break;  
     default:
       title = '';
   }


### PR DESCRIPTION
Addresses [Issue 395](https://github.com/5calls/5calls/issues/395) which is concerned with state legislators having the correct prefix. Right now, all state reps and senators get the "Senator" prefix. 

The `currentContact` object has an `area` property that can determine whether a legislator is state rep or state senator. The identifications seem to work as follows:
"House" means National Rep
"Senate" means National Senator
"StateLower" and "StateUpper" means Local Legislator

@nickoneill has said that we target other non-legislators, so we are leaving those folks without a prefix. 

Will add test for `getContactNameWithTitle`.