### PR TITLE
Improve accessibility of CallCount progress bar

### DIFF
--- a/src/components/shared/CallCount.tsx
+++ b/src/components/shared/CallCount.tsx
@@ -11,54 +11,32 @@ export interface Props {
 }
 
 export const CallCount: React.StatelessComponent<Props> = (props: Props) => {
-  let callGoal = 100;
-  if (props.totalCount >= 100) {
-    callGoal = 500;
-  }
-  if (props.totalCount >= 500) {
-    callGoal = 1000;
-  }
-  if (props.totalCount >= 1000) {
-    callGoal = 5000;
-  }
-  if (props.totalCount >= 5000) {
-    callGoal = 10000;
-  }
-  if (props.totalCount >= 10000) {
-    callGoal = 50000;
-  }
-  if (props.totalCount >= 50000) {
-    callGoal = 100000;
-  }
-  if (props.totalCount >= 100000) {
-    callGoal = 500000;
-  }
-  if (props.totalCount >= 500000) {
-    callGoal = 1000000;
-  }
-  if (props.totalCount >= 1000000) {
-    callGoal = 2000000;
-  }
-  if (props.totalCount >= 2000000) {
-    callGoal = 5000000;
+
+  const closestTenPower = Math.pow(10, Math.ceil(Math.log10(props.totalCount + 1)));
+
+  let callGoal = closestTenPower;
+  if (closestTenPower / 2 > (props.totalCount)) {
+    callGoal = Math.round(closestTenPower / 2);
   }
 
   const pctDone = (props.totalCount / callGoal) * 100;
-  const pctStyle = {width: `${pctDone}%`};    
+  const pctStyle = {width: `${pctDone - 2}%`};
+  const totalCalls = formatNumber(props.totalCount);
 
   const callText = props.minimal ?
-    `${formatNumber(props.totalCount)} Calls`
+    `${totalCalls} Calls`
     :
-    `Together we've made ${formatNumber(props.totalCount)} Calls!`;
+    `Together we've made ${totalCalls} Calls!`;
 
   return (
-    <div>
+    <div className="progress-block">
+      <div className="progress__label">{callText}</div>
       <div className="progress progress__large">
-        <p className="totaltext">{callText}</p>
+        <p className="totaltext">{totalCalls}</p>
         <span className="progress__border">&nbsp;</span>
-        <span className="progress__goal">{formatNumber(callGoal)}</span>
         <span style={pctStyle} className="progress__total" />
       </div>
+      <div className="progress__goal">Goal: {formatNumber(callGoal)}</div>
     </div>
   );
 };

--- a/src/components/shared/scss/_hypothesis.scss
+++ b/src/components/shared/scss/_hypothesis.scss
@@ -28,7 +28,7 @@
   }
 
   &__text {
-    .progress {
+    .progress-block {
       margin-bottom: 30px;
     }
 

--- a/src/components/shared/scss/_layout.scss
+++ b/src/components/shared/scss/_layout.scss
@@ -445,20 +445,29 @@ button {
   }
 }
 
+.progress-block {
+  font-size: 18px;
+}
+
 .progress {
   position: relative;
   width: 100%;
   height: 20px;
-  margin: 0 20px 10px 0;
+  margin: 0 20px 5px 0;
   background-color: white;
 
   p.totaltext {
     z-index: 3;
     position: absolute;
-    margin: 1px 8px;
+    margin: 1px 16px;
 
-    font-size: 28px;
+    font-size: 18px;
+    line-height: 40px;
     color: #fff;
+
+    @include bp(medium) {
+      display: none;
+    }
   }
 
   &__total {
@@ -466,38 +475,35 @@ button {
     position: relative;
     display: inline-block;
     min-width: 10%;
-    height: 20px;
+    height: 12px;
     background-color: $blue;
 
     color: white;
     text-align: right;
     padding-right: 5px;
     line-height: 21px;
-    border-radius: 5px;
+    border-radius: 100px;
+    margin-top: 4px;
+    margin-left: 4px;
   }
 
   &__border {
     z-index: 1;
     position: absolute;
     width: 100%;
-    background-color: $blue-light;
-    border-radius: 5px;
+    border-radius: 100px;
+    border: 2px solid $blue;
   }
 
   &__goal {
-    z-index: 3;
-    position: absolute;
     text-align: right;
-    width: 100%;
-    text-align: right;
-    height: 20px;
-    padding-right: 5px;
-    line-height: 21px;
-    color: #fff;
+    color: $blue;
+  }
 
-    @include bp(medium) {
-      display: none;
-    }
+  &__label {
+    margin-top: 15px;
+    margin-bottom: 5px;
+    text-align: center;
   }
 }
 
@@ -505,7 +511,7 @@ button {
   height: 40px;
 
   .progress__total {
-    height: 40px;
+    height: 32px;
     // line-height: 26px;
   }
 


### PR DESCRIPTION
I noticed that the text contrast (white on light blue) in the CallCount progress bar did not adhere to the [WebAIM guidelines](https://webaim.org/resources/contrastchecker/)

This tweak to CallCount styling updates the style of the progress bar by moving the label text (goal and current count) to be labels outside of the progress bar itself.

Additionally, this commit includes a refactor of the logic in the CallCount that computes the current goal to display.  It was previously hardcoded to a list of possible values.  Now, it computes the goal dynamically by determining the next power of ten (10,100,1000, etc) to shoot for, or the halfway point (50,500,5000, etc).

This way, as the site usage grows, the logic will grow with it and no updates will be needed when the progress bar continues to advance.

This seemed like a small refactor / accessibility fix that did not require opening an issue through the product guidelines.