### PR TITLE
Run End-to-End Tests on CircleCI (using Browserstack)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
             wget --retry-connrefused --no-check-certificate -T 60 localhost:3000
 
             # Actually do the tests
-            yarn web-tests:browserstack
+            yarn run web-tests:browserstack
             EXIT_CODE=$?
 
             # Stop server

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,20 @@ jobs:
         
       # run tests!
       - run: yarn test
+
+      - run:
+          name: "End-to-End Tests"
+          command: |
+            # Start test server
+            yarn start &
+            SERVER_PID=$!
+            # ...and wait for it to be ready
+            wget --retry-connrefused --no-check-certificate -T 60 localhost:3000
+
+            # Actually do the tests
+            yarn web-tests:browserstack
+            EXIT_CODE=$?
+
+            # Stop server
+            kill -9 $SERVER_PID
+            exit $EXIT_CODE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:8.12
 
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,9 @@ jobs:
             yarn start &
             SERVER_PID=$!
             # ...and wait for it to be ready
-            wget --retry-connrefused --no-check-certificate -T 60 localhost:3000
+            echo 'Polling server until ready...'
+            wget --retry-connrefused --no-check-certificate --no-verbose -T 60 localhost:3000
+            echo ''
 
             # Actually do the tests
             yarn run web-tests:browserstack

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
           name: "End-to-End Tests"
           command: |
             export FORCE_COLOR=1
-            
+            export BROWSERSTACK_PROJECT_NAME=5calls
+            export BROWSERSTACK_BUILD_ID="CIRCLE:$CIRCLE_BUILD_NUM"
+
             # Start test server
             yarn start &
             SERVER_PID=$!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ jobs:
       - run:
           name: "End-to-End Tests"
           command: |
+            export FORCE_COLOR=1
+            
             # Start test server
             yarn start &
             SERVER_PID=$!

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or if you have access to browserstack, you may run on multiple browsers using th
 `yarn web-tests:browserstack`
 
 #### Running on browserstack
-To run on browserstack, ensure that you have environment variables set for BOWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME to the values of your browserstack account
+To run on browserstack, ensure that you have environment variables set for BROWSERSTACK_ACCESS_KEY and BROWSERSTACK_USERNAME to the values of your browserstack account
 You may view test results on the [dashboard](https://automate.browserstack.com/builds)
 
 #### Debugging and running individual tests

--- a/runner.js
+++ b/runner.js
@@ -9,9 +9,9 @@ const browsers = [
   ['browserstack:safari@11.1:OS X High Sierra'],
 ];
 
-const runTest = async browser => {
+const runTest = browser => {
   console.log('starting tests');
-  await createTestCafe('localhost', 1337, 1338)
+  return createTestCafe('localhost', 1337, 1338)
     .then(tc => {
       testcafe = tc;
       const runner = testcafe.createRunner();
@@ -29,24 +29,29 @@ const runTest = async browser => {
     .then(async failedCount => {
       console.log('Tests failed: ' + failedCount);
       await testcafe.close();
-      return;
+      return {failedCount};
     });
 }
 
 const runAllBrowsers = async () => {
+  let failedCount = 0;
   for (const browser of browsers) {
-    await runTest(browser);
+    const result = await runTest(browser);
+    failedCount += result.failedCount;
   }
+  return {failedCount};
 }
 
 const runE2ETests = () => {
   axios.get('http://localhost:3000')
-    .then(resp => {
-      runAllBrowsers();
+    .then(resp => runAllBrowsers())
+    .then(result => {
+      console.log(`\nTotal Failures: ${result.failedCount}`);
+      process.exit(result.failedCount === 0 ? 0 : 2);
     })
     .catch(err => {
       console.log('Please start the site locally before running tests by running "yarn start"');
-      return;
+      process.exit(1);
     });
 }
 

--- a/runner.js
+++ b/runner.js
@@ -20,10 +20,7 @@ const runTest = browser => {
         .src(['web-tests/*.ts'])
         .browsers(browser)
         .run({
-          assertionTimeout: 8000,
-          pageLoadTimeout: 10000,
-          selectorTimeout: 20000,
-          speed: 0.25
+          speed: 0.5
         });
     })
     .then(async failedCount => {

--- a/runner.js
+++ b/runner.js
@@ -19,7 +19,12 @@ const runTest = async browser => {
       return runner
         .src(['web-tests/*.ts'])
         .browsers(browser)
-        .run();
+        .run({
+          assertionTimeout: 8000,
+          pageLoadTimeout: 10000,
+          selectorTimeout: 20000,
+          speed: 0.5
+        });
     })
     .then(async failedCount => {
       console.log('Tests failed: ' + failedCount);

--- a/runner.js
+++ b/runner.js
@@ -23,7 +23,7 @@ const runTest = async browser => {
           assertionTimeout: 8000,
           pageLoadTimeout: 10000,
           selectorTimeout: 20000,
-          speed: 0.5
+          speed: 0.25
         });
     })
     .then(async failedCount => {

--- a/web-tests/complete_call.ts
+++ b/web-tests/complete_call.ts
@@ -13,11 +13,11 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Complete Call`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(10000);
+    await waitForReact(15000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable
-test('Call buttons navigate to done page when clicked trhough', async t => {
+test('Call buttons navigate to done page when clicked through', async t => {
   const Sidebar = await ReactSelector('Sidebar');
 
   const IssueItems = await Sidebar.findReact('li');

--- a/web-tests/complete_call.ts
+++ b/web-tests/complete_call.ts
@@ -16,8 +16,10 @@ fixture`Complete Call`
     await waitForReact(15000);
   });
 
+const skipOnCi = process.env.CI ? test.skip : test;
+
 // tslint:disable-next-line:no-shadowed-variable
-test('Call buttons navigate to done page when clicked through', async t => {
+skipOnCi('Call buttons navigate to done page when clicked through', async t => {
   // const Sidebar = await ReactSelector('Sidebar');
   // const IssueItems = await Sidebar.findReact('li');
   // // FIXME: make this choice of items stable. The data in these tests comes

--- a/web-tests/complete_call.ts
+++ b/web-tests/complete_call.ts
@@ -13,11 +13,11 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Complete Call`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(7000);
+    await waitForReact(10000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable
-test('Call buttons navigate to done page wwhen clicked trhough', async t => {
+test('Call buttons navigate to done page when clicked trhough', async t => {
   const Sidebar = await ReactSelector('Sidebar');
 
   const IssueItems = await Sidebar.findReact('li');

--- a/web-tests/complete_call.ts
+++ b/web-tests/complete_call.ts
@@ -18,12 +18,27 @@ fixture`Complete Call`
 
 // tslint:disable-next-line:no-shadowed-variable
 test('Call buttons navigate to done page when clicked through', async t => {
-  const Sidebar = await ReactSelector('Sidebar');
+  // const Sidebar = await ReactSelector('Sidebar');
+  // const IssueItems = await Sidebar.findReact('li');
+  // // FIXME: make this choice of items stable. The data in these tests comes
+  // // from a live API and is therefore not predictable. Different data can lead
+  // // to different renderings, some of will cause this test to fail.
+  // const firstIssue = IssueItems.nth(1);
+  // const linkComponent = await firstIssue.findReact('a');
+  // const link = await linkComponent.getAttribute('href');
 
-  const IssueItems = await Sidebar.findReact('li');
-  const firstIssue = IssueItems.nth(1);
-  const linkComponent = await firstIssue.findReact('a');
-  const link = await linkComponent.getAttribute('href');
+  // FIXME: the above code using React-based selectors has been commented out
+  // because it doesn't seem to be very reliable in practice (it often hangs
+  // waiting for components to show up even when they are verifiably there).
+  // This standard HTML-element based selector code appears to be reliable, but
+  // getting the React stuff above to work would be nice.
+
+  // FIXME: make this nth-child choice stable. The data in these tests comes
+  // from a live API and is therefore not predictable. Different data can lead
+  // to different renderings, some of will cause this test to fail.
+  const firstIssue = Selector('.layout__side .issues-list > li:nth-child(3) a');
+  const link = await firstIssue.getAttribute('href');
+
   await t
     .click(firstIssue)
     .navigateTo(link);

--- a/web-tests/footer.ts
+++ b/web-tests/footer.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Footer`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(5000);
+    await waitForReact(10000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/footer.ts
+++ b/web-tests/footer.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Footer`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(10000);
+    await waitForReact(15000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/header.ts
+++ b/web-tests/header.ts
@@ -14,7 +14,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Header`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(5000);
+    await waitForReact(10000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/header.ts
+++ b/web-tests/header.ts
@@ -14,7 +14,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Header`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(10000);
+    await waitForReact(15000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -16,8 +16,10 @@ fixture`IssuePage`
     await waitForReact(15000);
   });
 
+const skipOnCi = process.env.CI ? test.skip : test;
+
 // tslint:disable-next-line:no-shadowed-variable
-test('Link on sidebar navigates to issue page', async t => {
+skipOnCi('Link on sidebar navigates to issue page', async t => {
   // const Sidebar = await ReactSelector('Sidebar');
   // const IssueItems = await Sidebar.findReact('li');
   // // FIXME: make this `nth()` choice stable. The data in these tests comes

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -18,12 +18,27 @@ fixture`IssuePage`
 
 // tslint:disable-next-line:no-shadowed-variable
 test('Link on sidebar navigates to issue page', async t => {
-  const Sidebar = await ReactSelector('Sidebar');
+  // const Sidebar = await ReactSelector('Sidebar');
+  // const IssueItems = await Sidebar.findReact('li');
+  // // FIXME: make this `nth()` choice stable. The data in these tests comes
+  // // from a live API and is therefore not predictable. Different data can lead
+  // // to different renderings, some of will cause this test to fail.
+  // const firstIssue = IssueItems.nth(2);
+  // const linkComponent = await firstIssue.findReact('a');
+  // const link = await linkComponent.getAttribute('href');
+  
+  // FIXME: the above code using React-based selectors has been commented out
+  // because it doesn't seem to be very reliable in practice (it often hangs
+  // waiting for components to show up even when they are verifiably there).
+  // This standard HTML-element based selector code appears to be reliable, but
+  // getting the React stuff above to work would be nice.
 
-  const IssueItems = await Sidebar.findReact('li');
-  const firstIssue = IssueItems.nth(1);
-  const linkComponent = await firstIssue.findReact('a');
-  const link = await linkComponent.getAttribute('href');
+  // FIXME: make this nth-child choice stable. The data in these tests comes
+  // from a live API and is therefore not predictable. Different data can lead
+  // to different renderings, some of will cause this test to fail.
+  const firstIssue = Selector('.layout__side .issues-list > li:nth-child(5) a');
+  const link = await firstIssue.getAttribute('href');
+
   await t
     .click(firstIssue)
     .navigateTo(link);
@@ -65,6 +80,9 @@ test('Link on sidebar navigates to issue page', async t => {
   const reasonBody = await Selector('.call__contact__reason');
   await t.expect(reasonBody.exists).ok('The call contact reason is missing');
 
+  // FIXME: this will frequently fail because not all issue pages render this
+  // field. See where /src/components/call/ContactOffices.tsx both returns early
+  // and branches, providing multiple conditions in which this will fail.
   const contactOffice = await Selector('.call__contact__show-field-offices');
   await t.expect(contactOffice.exists).ok('The ContactOffice component is missing');
 

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -16,16 +16,13 @@ fixture`IssuePage`
     await waitForReact(10000);
   });
 
-// FIXME: this test seems to reliably fail in all browsers on Browserstack, so
-// it's skipped for now.
 // tslint:disable-next-line:no-shadowed-variable
-test.skip('Link on sidebar navigates to issue page', async t => {
+test('Link on sidebar navigates to issue page', async t => {
   const Sidebar = await ReactSelector('Sidebar');
 
   const IssueItems = await Sidebar.findReact('li');
   const firstIssue = IssueItems.nth(1);
   const linkComponent = await firstIssue.findReact('a');
-  // FIXME: This line is failing in Chrome & Firefox on Browserstack
   const link = await linkComponent.getAttribute('href');
   await t
     .click(firstIssue)
@@ -69,7 +66,6 @@ test.skip('Link on sidebar navigates to issue page', async t => {
   await t.expect(reasonBody.exists).ok('The call contact reason is missing');
 
   const contactOffice = await Selector('.call__contact__show-field-offices');
-  // FIXME: this line is failing in Safari on Browserstack
   await t.expect(contactOffice.exists).ok('The ContactOffice component is missing');
 
   // check for the call script

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`IssuePage`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(10000);
+    await waitForReact(15000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`IssuePage`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(7000);
+    await waitForReact(10000);
   });
 
 // FIXME: this test seems to reliably fail in all browsers on Browserstack, so

--- a/web-tests/issue_page.ts
+++ b/web-tests/issue_page.ts
@@ -16,13 +16,16 @@ fixture`IssuePage`
     await waitForReact(7000);
   });
 
+// FIXME: this test seems to reliably fail in all browsers on Browserstack, so
+// it's skipped for now.
 // tslint:disable-next-line:no-shadowed-variable
-test('Link on sidebar navigates to issue page', async t => {
+test.skip('Link on sidebar navigates to issue page', async t => {
   const Sidebar = await ReactSelector('Sidebar');
 
   const IssueItems = await Sidebar.findReact('li');
   const firstIssue = IssueItems.nth(1);
   const linkComponent = await firstIssue.findReact('a');
+  // FIXME: This line is failing in Chrome & Firefox on Browserstack
   const link = await linkComponent.getAttribute('href');
   await t
     .click(firstIssue)
@@ -66,7 +69,8 @@ test('Link on sidebar navigates to issue page', async t => {
   await t.expect(reasonBody.exists).ok('The call contact reason is missing');
 
   const contactOffice = await Selector('.call__contact__show-field-offices');
-  await t.expect(contactOffice.exists).ok('The ContactOffice component is missint');
+  // FIXME: this line is failing in Safari on Browserstack
+  await t.expect(contactOffice.exists).ok('The ContactOffice component is missing');
 
   // check for the call script
   const script = await Selector('.call__script');

--- a/web-tests/sidebar.ts
+++ b/web-tests/sidebar.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Sidebar`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(5000);
+    await waitForReact(10000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable

--- a/web-tests/sidebar.ts
+++ b/web-tests/sidebar.ts
@@ -13,7 +13,7 @@ const getWindowLocation = ClientFunction(() => window.location.href);
 fixture`Sidebar`
   .page`http://localhost:3000`
   .beforeEach(async () => {
-    await waitForReact(10000);
+    await waitForReact(15000);
   });
 
 // tslint:disable-next-line:no-shadowed-variable


### PR DESCRIPTION
This should resolve #291 by running most of the end-to-end tests with Browserstack in our normal CircleCI builds. **Note: someone who has the right Browserstack credentials will need to set `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` in the CircleCI console in order for this to work.**

The vast majority of the heavy lifting needed back when we first looked at this is now already done by Testcafe (and the testcafe-browser-provider-browserstack plugin). Setting up our dev server to run in the background is fairly straightforward. I actually spent most of the time here dealing with other intermittent failures that made the end-to-end tests unreliable in the first place:

- Weird, intermittent failures (about 1/3 of the time) caused by the `testcafe-react-selectors` package (see https://github.com/5calls/5calls/commit/31e8920661aaaa6797771f1fe22e57e024589f75#diff-9d5b2b71594d1c8b15f7e2762d4d99a3R30). To solve this, I wound up commenting out these specific React-based selectors in favor of using simple HTML-based selectors. I definitely didn’t have time to dig into what kind of weird race condition is really happening here, but this change made tests immediately more reliable. I left the old code present and commented out as I assume it would be preferable to switch back to if we can solve the problem.

- Failures caused by changing data from the API. Two of the tests are looking for content that will only be present for some types of issues and, since the API is regularly changing what data you get (and even sending different data depending on where you are running the test from), it’s pretty hard to reliably know whether the test will receive the data it needs to succeed. What we really need here is some kind of fixture, mock API, or proxy API server that sends pre-recorded responses. That’s a big change, though, so I’m not attempting it in this PR. Instead, I’ve simply skipped those tests when running on CI.

I also noticed that CircleCI is configured to run the tests on Node.js v7, which is an unstable release line. (This is the reason I had to [use `process.exit(code)` instead of `process.exitCode = code`](https://github.com/5calls/5calls/commit/befe365d7985291475220b611dae825c0b015e91#diff-b9c2b69f1fd91e39237ff14152db7467R50).) I’m happy to add a commit here or to create a separate PR to upgrade to Node.js v8. Let me know whichever is preferable.