### PR TITLE
add rel=noopener

### DIFF
--- a/src/components/donation/Donation.tsx
+++ b/src/components/donation/Donation.tsx
@@ -19,19 +19,19 @@ export class Donation extends React.Component<Props, State> {
               Get Involved:
             </p>
             {/* <div className="logo__header__donatebutton">
-              <a href={`${Constants.WRITER_APPLY_URL}`} target="_blank">Apply</a>
+              <a href={`${Constants.WRITER_APPLY_URL}`} target="_blank" rel="noopener">Apply</a>
               <p>Research and Write Topics</p>
             </div> */}
             <div className="logo__header__donatebutton">
-              <a href="https://airtable.com/shrSFvr3AlMKRRssx" target="_blank">Contact Us</a>
+              <a href="https://airtable.com/shrSFvr3AlMKRRssx" target="_blank" rel="noopener">Contact Us</a>
               <p>Get Your Own 5 Calls Page</p>
             </div>
             <div className="logo__header__donatebutton">
-              <a href={`${Constants.CODE_PROJECT_URL}`} target="_blank">Projects</a>
+              <a href={`${Constants.CODE_PROJECT_URL}`} target="_blank" rel="noopener">Projects</a>
               <p>Contribute Design or Code</p>
             </div>
             <div className="logo__header__donatebutton">
-              <a href={`${Constants.DONATE_URL}?amount=25`} target="_blank">Donate</a>
+              <a href={`${Constants.DONATE_URL}?amount=25`} target="_blank" rel="noopener">Donate</a>
               <p>Be a 5 Calls Supporter</p>
             </div>
           </div>

--- a/src/components/donation/__snapshots__/Donation.test.tsx.snap
+++ b/src/components/donation/__snapshots__/Donation.test.tsx.snap
@@ -20,7 +20,8 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://airtable.com/shrSFvr3AlMKRRssx"
-          target="_blank" rel="noopener"
+          rel="noopener"
+          target="_blank"
         >
           Contact Us
         </a>
@@ -33,7 +34,8 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://github.com/5calls/5calls/wiki/Getting-Involved-with-5-Calls-Development"
-          target="_blank" rel="noopener"
+          rel="noopener"
+          target="_blank"
         >
           Projects
         </a>
@@ -46,7 +48,8 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://secure.actblue.com/donate/5calls-donate?amount=25"
-          target="_blank" rel="noopener"
+          rel="noopener"
+          target="_blank"
         >
           Donate
         </a>

--- a/src/components/donation/__snapshots__/Donation.test.tsx.snap
+++ b/src/components/donation/__snapshots__/Donation.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://airtable.com/shrSFvr3AlMKRRssx"
-          target="_blank"
+          target="_blank" rel="noopener"
         >
           Contact Us
         </a>
@@ -33,7 +33,7 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://github.com/5calls/5calls/wiki/Getting-Involved-with-5-Calls-Development"
-          target="_blank"
+          target="_blank" rel="noopener"
         >
           Projects
         </a>
@@ -46,7 +46,7 @@ exports[`should render Donation component properly 1`] = `
       >
         <a
           href="https://secure.actblue.com/donate/5calls-donate?amount=25"
-          target="_blank"
+          target="_blank" rel="noopener"
         >
           Donate
         </a>

--- a/src/components/home/HomeExtras.tsx
+++ b/src/components/home/HomeExtras.tsx
@@ -48,25 +48,25 @@ export const HomeExtras: React.StatelessComponent = () => {
       <ul>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://techcrunch.com/2017/01/25/5-calls-debuts-what-may-be-the-easiest-way-to-call-your-reps-yet/" target="_blank">
+          <a href="https://techcrunch.com/2017/01/25/5-calls-debuts-what-may-be-the-easiest-way-to-call-your-reps-yet/" target="_blank" rel="noopener">
             <img src="/img/logo-techcrunch.png" alt="TechCrunch" />
           </a>
         </li>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="http://www.vogue.com/article/five-calls-best-political-activist-hack" target="_blank">
+          <a href="http://www.vogue.com/article/five-calls-best-political-activist-hack" target="_blank" rel="noopener">
             <img src="/img/logo-vogue.png" alt="Vogue" />
           </a>
         </li>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="http://www.huffingtonpost.com/entry/5-calls-congress-phone_us_588ada64e4b0230ce61b26d7" target="_blank">
+          <a href="http://www.huffingtonpost.com/entry/5-calls-congress-phone_us_588ada64e4b0230ce61b26d7" target="_blank" rel="noopener">
             <img src="/img/logo-huffpost.png" alt="HuffPost" />
           </a>
         </li>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://www.bloomberg.com/news/articles/2017-02-09/silicon-valley-fights-trump-in-its-free-time" target="_blank">
+          <a href="https://www.bloomberg.com/news/articles/2017-02-09/silicon-valley-fights-trump-in-its-free-time" target="_blank" rel="noopener">
             <img src="/img/logo-businessweek.png" alt="Bloomberg Businessweek" />
           </a>
         </li>
@@ -79,15 +79,15 @@ export const HomeExtras: React.StatelessComponent = () => {
       <ul>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://www.youtube.com/watch?v=rsazVtf1HP4" target="_blank"><img src="/img/video-mmoore.jpg" alt="Michael Moore talking about 5 Calls on MSNBC" /></a>
+          <a href="https://www.youtube.com/watch?v=rsazVtf1HP4" target="_blank" rel="noopener"><img src="/img/video-mmoore.jpg" alt="Michael Moore talking about 5 Calls on MSNBC" /></a>
         </li>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://www.youtube.com/watch?v=N62ViRRn61I" target="_blank"><img src="/img/video-app.jpg" alt="How to use the 5 Calls iPhone App" /></a>
+          <a href="https://www.youtube.com/watch?v=N62ViRRn61I" target="_blank" rel="noopener"><img src="/img/video-app.jpg" alt="How to use the 5 Calls iPhone App" /></a>
         </li>
         <li>
           {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://www.youtube.com/watch?v=wwoJqYXvh9s" target="_blank"><img src="/img/video-shower.jpg" alt="When do you make your 5 Calls?" /></a>
+          <a href="https://www.youtube.com/watch?v=wwoJqYXvh9s" target="_blank" rel="noopener"><img src="/img/video-shower.jpg" alt="When do you make your 5 Calls?" /></a>
         </li>
       </ul>
       </div>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -19,7 +19,7 @@ const Navigation: React.StatelessComponent = () => {
           </Link>
         </li>
         <li>
-          <a href="https://github.com/5calls/5calls" target="_blank"><i aria-hidden="true" className="fa fa-github" />
+          <a href="https://github.com/5calls/5calls" target="_blank" rel="noopener"><i aria-hidden="true" className="fa fa-github" />
             <span>{i18n.t('footer.openSource')}</span>
           </a>
         </li>
@@ -45,7 +45,7 @@ const Navigation: React.StatelessComponent = () => {
       </ul>
       <div className="colophon__center">
         <p>© 2018 5 Calls Civic Action is a 501(c)4 non-profit that helps citizens make their voices heard.</p>
-        <p><a href="http://ipinfo.io" target="_blank">{i18n.t('footer.ipGeolocation')}</a></p>
+        <p><a href="http://ipinfo.io" target="_blank" rel="noopener">{i18n.t('footer.ipGeolocation')}</a></p>
       </div>
       <div style={{'clear': 'both'}} />
     </div>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -19,14 +19,14 @@ const Navigation: React.StatelessComponent = () => {
           </Link>
         </li>
         <li>
-          {/*tslint:disable-next-line:max-line-length*/}
-          <a href="https://github.com/5calls/5calls" target="_blank" rel="noopener"><i aria-hidden="true" className="fa fa-github" />
+          <a href="https://github.com/5calls/5calls" target="_blank" rel="noopener">
+            <i aria-hidden="true" className="fa fa-github" />
             <span>{i18n.t('footer.openSource')}</span>
           </a>
         </li>
         <li>
-          {/*tslint:disable-next-line:max-line-length*/}
-          <a href="/privacy" data-no-routing="data-no-routing"><i aria-hidden="true" className="fa fa-shield" />
+          <a href="/privacy" data-no-routing="data-no-routing">
+            <i aria-hidden="true" className="fa fa-shield" />
             <span>{i18n.t('footer.privacy')}</span>
           </a>
         </li>

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -19,6 +19,7 @@ const Navigation: React.StatelessComponent = () => {
           </Link>
         </li>
         <li>
+          {/*tslint:disable-next-line:max-line-length*/}
           <a href="https://github.com/5calls/5calls" target="_blank" rel="noopener"><i aria-hidden="true" className="fa fa-github" />
             <span>{i18n.t('footer.openSource')}</span>
           </a>

--- a/src/components/postcards/Postcards.tsx
+++ b/src/components/postcards/Postcards.tsx
@@ -29,15 +29,15 @@ export const Postcards: React.StatelessComponent<Props> = (props: Props) => (
     <ul>
       <li>Polls will be open from 7am - 7pm.</li>
       {/*tslint:disable-next-line:max-line-length*/}
-      <li>Polling locations can be found at <a href="http://www.alabamavotes.gov" target="_blank">www.alabamavotes.gov</a></li>
+      <li>Polling locations can be found at <a href="http://www.alabamavotes.gov" target="_blank" rel="noopener">www.alabamavotes.gov</a></li>
       {/*tslint:disable-next-line:max-line-length*/}
-      <li>Since 2014, voters in Alabama have been required to bring ID to the polls. They can find information on acceptable ID or how to get a free ID at <a href="http://www.alabamavotes.gov" target="_blank">www.alabamavotes.gov</a></li>
+      <li>Since 2014, voters in Alabama have been required to bring ID to the polls. They can find information on acceptable ID or how to get a free ID at <a href="http://www.alabamavotes.gov" target="_blank" rel="noopener">www.alabamavotes.gov</a></li>
       {/*tslint:disable-next-line:max-line-length*/}
       <li>Keep messaging positive and encouraging. The best way to connect with other voters is to be sincere and authentic.</li>
     </ul>
     <h3>Postcard message examples:</h3>
     <blockquote>
-      <p>Dear Voter,</p> 
+      <p>Dear Voter,</p>
       {/*tslint:disable-next-line:max-line-length*/}
       <p>Participating in elections is a critical way to make your voice heard in our democracy! Every vote counts! Don’t miss your chance to vote in the special election on Dec. 12. Polls are open from 7am - 7pm, more info can be found at www.alabamavotes.gov</p>
       <p>Thank you for being a voter!</p>


### PR DESCRIPTION
[Links that use target="_blank" should all use rel="noopener" for security and performance reasons.](https://developers.google.com/web/tools/lighthouse/audits/noopener)

There are some links in the `Promotion` component that I didn't alter since they are doing something more involved with share widgets that I didn't fully understand.