### PR TITLE
scroll to heading on mobile

### DIFF
--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -44,7 +44,7 @@ export class Call extends React.Component<Props, State> {
       return;
     }
 
-    const pageTitle = this.containerRef.current.querySelector('h1');
+    const pageTitle = this.containerRef.current.querySelector("[data-scroll-anchor]");
     if (!pageTitle) {
       return;
     }
@@ -96,14 +96,15 @@ export class Call extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    this.scrollToTitleOnMobile();
+    // wait a tick to ensure rendering of children is complete
+    setTimeout(this.scrollToTitleOnMobile, 1);
   }
 
   componentDidUpdate(prevProps: Props) {
     if (!isEqual(prevProps, this.props)) {
       this.setState(this.setStateFromProps(this.props));
+      this.scrollToTitleOnMobile();
     }
-    this.scrollToTitleOnMobile();
   }
 
   // this should obviously be somewhere on issue but as an interface and not a class I don't know where...

--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -22,11 +22,48 @@ export interface State {
   numberContactsLeft: number;
 }
 
+const BREAKPOINT_MEDIUM = 768;
+
 export class Call extends React.Component<Props, State> {
+
+  private containerRef = React.createRef<HTMLElement>();
   constructor(props: Props) {
     super(props);
     // set initial state
     this.state = this.setStateFromProps(props);
+  }
+
+  scrollToTitleOnMobile = (): void => {
+    if (!window.matchMedia) {
+      return;
+    }
+    if (window.matchMedia(`(min-width: ${BREAKPOINT_MEDIUM}px)`).matches) {
+      return;
+    }
+    if (!this.containerRef || !this.containerRef.current) {
+      return;
+    }
+
+    const pageTitle = this.containerRef.current.querySelector('h1');
+    if (!pageTitle) {
+      return;
+    }
+
+    const crossBrowserScrollY = window.scrollY || window.pageYOffset || 0;
+
+    const h1ScrollTop =
+      pageTitle.getBoundingClientRect().top + crossBrowserScrollY - 5;
+    const canSmoothScroll = 'scrollBehavior' in document.body.style;
+
+    if (canSmoothScroll) {
+      window.scrollTo({
+        left: 0,
+        top: h1ScrollTop,
+        behavior: 'smooth'
+      });
+    } else {
+      window.scrollTo(0, h1ScrollTop);
+    }
   }
 
   /**
@@ -58,11 +95,15 @@ export class Call extends React.Component<Props, State> {
     };
   }
 
-  componentDidUpdate(prevProps: Props) {
+  componentDidMount() {
+    this.scrollToTitleOnMobile();
+  }
 
+  componentDidUpdate(prevProps: Props) {
     if (!isEqual(prevProps, this.props)) {
       this.setState(this.setStateFromProps(this.props));
     }
+    this.scrollToTitleOnMobile();
   }
 
   // this should obviously be somewhere on issue but as an interface and not a class I don't know where...
@@ -116,7 +157,7 @@ export class Call extends React.Component<Props, State> {
     return (
       <locationStateContext.Consumer>
       { locationState =>
-        <section className="call">
+        <section className="call" ref={this.containerRef}>
           <CallHeaderTranslatable
             invalidAddress={locationState.invalidAddress}
             currentIssue={this.state.issue}
@@ -148,7 +189,7 @@ export class Call extends React.Component<Props, State> {
                     eventEmitter={eventManager.ee}
                     numberContactsLeft={this.state.numberContactsLeft}
                     currentContactId={(this.state.currentContact ? this.state.currentContact.id : '')}
-                  />                
+                  />
                 }
               </eventContext.Consumer>
             }

--- a/src/components/call/Call.tsx
+++ b/src/components/call/Call.tsx
@@ -44,7 +44,7 @@ export class Call extends React.Component<Props, State> {
       return;
     }
 
-    const pageTitle = this.containerRef.current.querySelector("[data-scroll-anchor]");
+    const pageTitle = this.containerRef.current.querySelector('[data-scroll-anchor]');
     if (!pageTitle) {
       return;
     }

--- a/src/components/call/CallHeader.tsx
+++ b/src/components/call/CallHeader.tsx
@@ -14,7 +14,7 @@ export const CallHeader: React.StatelessComponent<Props> = ({ invalidAddress, cu
   if (currentIssue) {
     return (
       <header className="call__header">
-        <h1 className="call__title">{currentIssue.name}</h1>
+        <h1 className="call__title" data-scroll-anchor="true">{currentIssue.name}</h1>
         <div className="call__reason">
           <ReactMarkdown source={currentIssue.reason}/>
         </div>


### PR DESCRIPTION
Hi, I saw [this issue](https://github.com/5calls/5calls/issues/424) had not been responded to for a while so I made a pr.

In this implementation, Chrome and Firefox will smooth scroll to the heading on screen sizes less than 768, while Safari and Edge will jump directly to the heading without the scroll animation.

I am relying on there being only 1 `h1` as a child of the `Call` component, but that is required by semantic HTML  so I think it's an ok tradeoff for not having to forward refs on the `CallHeader` component.

The scroll is currently also called when the component mounts, not sure if that was desired, if not I can remove. To be safe, I am triggering the scroll on all `componentDidUpdate`s, but it's possible it should only be called when certain props change, I wasn't sure.

Additionally, this should work in IE11, but I wasn't able to test it because it was [erroring on this line locally](https://github.com/5calls/5calls/blob/master/src/components/layout/Layout.tsx#L21) If you don't support IE11 than I can simplify the logic for the `crossBrowserScrollY ` variable.

I haven't done a lot of Typescript before, I would be happy to make any changes that are required.