### PR TITLE
Really fixed the markdown renderer with new tab links this time

### DIFF
--- a/src/components/call/CallHeader.tsx
+++ b/src/components/call/CallHeader.tsx
@@ -4,6 +4,7 @@ import i18n from '../../services/i18n';
 import * as ReactMarkdown from 'react-markdown';
 
 import { Issue } from '../../common/model';
+import { linkRefRenderer } from '../shared/markdown-utils';
 
 interface Props {
   invalidAddress: boolean;
@@ -19,7 +20,13 @@ export const CallHeader: React.StatelessComponent<Props> = ({
       <header className="call__header">
         <h1 className="call__title">{currentIssue.name}</h1>
         <div className="call__reason">
-          <ReactMarkdown source={currentIssue.reason} linkTarget="_blank" />
+          <ReactMarkdown
+            source={currentIssue.reason}
+            linkTarget="_blank"
+            renderers={{
+              linkReference: linkRefRenderer
+            }}
+          />
         </div>
       </header>
     );

--- a/src/components/call/FetchCall.tsx
+++ b/src/components/call/FetchCall.tsx
@@ -7,6 +7,7 @@ import { Issue, VoterContact } from '../../common/model';
 import { CallHeaderTranslatable, SupportOutcomes, ACAOutcomes } from './index';
 import { submitOutcome } from '../../redux/callState';
 import { locationStateContext } from '../../contexts';
+import { linkRefRenderer } from '../shared/markdown-utils';
 
 // This defines the props that we must pass into this component.
 export interface Props {
@@ -101,6 +102,7 @@ export default class FetchCall extends React.Component<Props, State> {
                 this.state.currentContact
               )}
               linkTarget="_blank"
+              renderers={{ linkReference: linkRefRenderer }}
             />
           </div>
           {this.props.issue.id === '51' ? (

--- a/src/components/call/Script.test.tsx
+++ b/src/components/call/Script.test.tsx
@@ -11,6 +11,7 @@ import {
   LocationFetchType
 } from '../../common/model';
 import { LocationState } from '../../redux/location';
+import { linkRefRenderer } from '../shared/markdown-utils';
 
 test('Script component should be rendered if passed a valid object', () => {
   const issue: Issue = Object.assign({}, new Issue(), {
@@ -75,7 +76,11 @@ describe('when the script text is shown', () => {
     );
     expect(
       wrapper.contains(
-        <ReactMarkdown source="script_text" linkTarget="_blank" />
+        <ReactMarkdown
+          source="script_text"
+          linkTarget="_blank"
+          renderers={{ linkReference: linkRefRenderer }}
+        />
       )
     ).toBe(true);
   });

--- a/src/components/call/Script.tsx
+++ b/src/components/call/Script.tsx
@@ -4,6 +4,7 @@ import { TranslationFunction } from 'i18next';
 import { translate } from 'react-i18next';
 import { Contact, Issue } from '../../common/model';
 import { LocationState } from '../../redux/location/reducer';
+import { linkRefRenderer } from '../shared/markdown-utils';
 
 interface Props {
   readonly issue: Issue;
@@ -75,7 +76,13 @@ export const Script: React.StatelessComponent<Props> = ({
       <div className="call__script">
         <h3 className="call__script__header">{t('script.yourScript')}</h3>
         <div className="call__script__body">
-          <ReactMarkdown source={formattedScript} linkTarget="_blank" />
+          <ReactMarkdown
+            source={formattedScript}
+            linkTarget="_blank"
+            renderers={{
+              linkReference: linkRefRenderer
+            }}
+          />
         </div>
       </div>
     );

--- a/src/components/shared/markdown-utils.tsx
+++ b/src/components/shared/markdown-utils.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+// writers use a lot of [NAME] in the text, which is markdown for a link reference
+// we won't ever use these without hrefs (I'm not sure who does) so we can return them unlinked
+export const linkRefRenderer = (reference): JSX.Element => {
+  if (!reference.href) {
+    return <>[{reference.children[0]}]</>;
+  }
+  return <a href={reference.ref}>{reference.children}</a>;
+};


### PR DESCRIPTION
Upgrading react-markdown broke some of the [NAME] text we often use. This removes the link reference renderer when there's no href (so like... almost always).