### PR TITLE
#465 call reason ol and ul sizing and line height updated

### DIFF
--- a/src/components/shared/scss/_call.scss
+++ b/src/components/shared/scss/_call.scss
@@ -245,8 +245,14 @@
 }
 
 .call__reason {
-  p {
+  p,
+  ol,
+  ul {
     line-height: 1.6;
+  }
+  ol,
+  ul {
+    font-size: $font-normal;
   }
 }
 


### PR DESCRIPTION
addresses #465 

I'm keeping the edits scoped to `.call__reason` since I didn't want to hunt down every `ol` in the site and make sure that they were supposed to be 18px.

#### After the edits:
![screen shot 2019-01-22 at 8 43 53 am](https://user-images.githubusercontent.com/3680488/51539456-0d28a680-1e22-11e9-8069-cabe3bd9f637.png)
