### PR TITLE
better responsive styles for representative on call page

### DIFF
--- a/src/components/call/ContactDetails.tsx
+++ b/src/components/call/ContactDetails.tsx
@@ -18,14 +18,18 @@ const ContactDetails: React.StatelessComponent<Props> = ({
       <div className="call__contact__image">
         <img alt="" src={currentContact.photoURL} />
       </div>
-      <h3 className="call__contact__name">{currentContact.contactDisplay()}</h3>
-      <p className="call__contact__phone">
-        {makePhoneLink(currentContact.phone)}
-      </p>
-      <ContactOffices
-        currentIssue={currentIssue}
-        currentContact={currentContact}
-      />
+      <div>
+        <h3 className="call__contact__name">
+          {currentContact.contactDisplay()}
+        </h3>
+        <p className="call__contact__phone">
+          {makePhoneLink(currentContact.phone)}
+        </p>
+        <ContactOffices
+          currentIssue={currentIssue}
+          currentContact={currentContact}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/shared/scss/_call.scss
+++ b/src/components/shared/scss/_call.scss
@@ -85,10 +85,8 @@
     }
 
     &__image {
-      margin-bottom: 0.5rem;
 
       @include bp(large) {
-        margin-bottom: 0;
         margin-right: 2rem;
       }
 
@@ -97,8 +95,8 @@
         width: 7rem;
 
         @include bp(medium) {
-          height: 9rem;
-          width: 9rem;
+          height: 8.5rem;
+          width: 8.5rem;
         }
 
         border-radius: 50%;

--- a/src/components/shared/scss/_call.scss
+++ b/src/components/shared/scss/_call.scss
@@ -107,7 +107,7 @@
       margin: 0;
       padding: 0;
 
-      font-size: 2rem;
+      font-size: 1.8rem;
       margin-top: 1rem;
       margin-bottom: 0.5rem;
 

--- a/src/components/shared/scss/_call.scss
+++ b/src/components/shared/scss/_call.scss
@@ -72,30 +72,55 @@
   }
 
   &__contact {
-    margin-top: 20px;
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    font-weight: bold;
+
+    @include bp(large) {
+      flex-direction: row;
+      margin-bottom: 1rem;
+      align-items: center;
+    }
 
     &__image {
-      overflow: hidden;
-      float: right;
-      height: 150px;
-      width: 150px;
-      border-radius: 50%;
-      background-color: $gray-xlight;
+      margin-bottom: 0.5rem;
 
-      img {
-        width: 100%;
-        height: auto;
+      @include bp(large) {
+        margin-bottom: 0;
+        margin-right: 2rem;
       }
 
-      @include max-width-bp(small) {
-        position: relative;
-        margin: auto;
+      img {
+        height: 7rem;
+        width: 7rem;
+
+        @include bp(medium) {
+          height: 9rem;
+          width: 9rem;
+        }
+
+        border-radius: 50%;
       }
     }
 
     &__name {
-      font-size: 47px;
+      margin: 0;
       padding: 0;
+
+      font-size: 2rem;
+      margin-top: 1rem;
+      margin-bottom: 0.5rem;
+
+      @include bp(small) {
+        font-size: 2.5rem;
+      }
+
+      @include bp(large) {
+        font-size: 2.75rem;
+        margin-bottom: 0;
+      }
 
       span {
         font-weight: normal;
@@ -103,7 +128,16 @@
     }
 
     &__phone {
-      font-size: $font-xxxlarge;
+      font-size: 2.4rem;
+
+      @include bp(small) {
+        font-size: 3rem;
+      }
+
+      @include bp(large) {
+        font-size: 4.25rem;
+        margin-top: 0;
+      }
       padding-top: 0;
       line-height: 1em;
     }
@@ -126,21 +160,6 @@
       list-style: none;
       margin: 0 0 16px 0;
       padding: 0;
-    }
-
-    &__name,
-    &__phone {
-      font-weight: bold;
-      margin: 0 150px 0 0;
-
-      @include max-width-bp(medium) {
-        font-size: $font-xlarge;
-      }
-
-      @include max-width-bp(small) {
-        font-size: $font-xlarge;
-        margin: 0;
-      }
     }
   }
 
@@ -190,7 +209,6 @@
   &__script__header,
   &__outcomes__header {
     font-weight: bold;
-    font-style: italic;
     font-size: $font-large;
   }
 


### PR DESCRIPTION
Before on mobile:

![screen shot 2019-01-25 at 12 04 32 pm](https://user-images.githubusercontent.com/3680488/51760877-939aed80-2099-11e9-8370-a286e0d00f00.png)

After on mobile:

![screen shot 2019-01-25 at 12 09 24 pm](https://user-images.githubusercontent.com/3680488/51761147-49fed280-209a-11e9-9a2b-a918212d60d9.png)

Before on desktop: 
![screen shot 2019-01-25 at 12 05 42 pm](https://user-images.githubusercontent.com/3680488/51760932-b75e3380-2099-11e9-82a6-8143fc5e1f0d.png)

After on desktop: 
![screen shot 2019-01-25 at 12 10 24 pm](https://user-images.githubusercontent.com/3680488/51761121-36ec0280-209a-11e9-87cc-2030601e2d2a.png)

I also removed the italic in the headlines  on the call page as a preference, but I could add it back

