### PR TITLE
Adopt our previous variable name to use field offices

### DIFF
--- a/src/common/models/contact.ts
+++ b/src/common/models/contact.ts
@@ -9,7 +9,8 @@ export class Contact {
   state: string;
   reason: string;
   area?: string;
-  fieldOffices?: FieldOffice[];
+  // tslint:disable-next-line:variable-name
+  field_offices?: FieldOffice[];
 
   public contactDisplay(): string {
     if (this.partyStateAbbr() !== '') {
@@ -38,5 +39,5 @@ export const mockContact = Object.assign(new Contact(), {
   state: 'CA',
   reason: 'This is your mock representative',
   area: undefined,
-  fieldOffices: []
+  field_offices: []
 });

--- a/src/components/call/ContactOffices.tsx
+++ b/src/components/call/ContactOffices.tsx
@@ -15,6 +15,7 @@ export interface State {
 export class ContactOffices extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
+
     this.state = { showFieldOfficeNumbers: false };
   }
 
@@ -32,8 +33,8 @@ export class ContactOffices extends React.Component<Props, State> {
 
   render() {
     if (
-      this.props.currentContact.fieldOffices == null ||
-      this.props.currentContact.fieldOffices.length === 0
+      this.props.currentContact.field_offices == null ||
+      this.props.currentContact.field_offices.length === 0
     ) {
       return <span />;
     }
@@ -45,8 +46,8 @@ export class ContactOffices extends React.Component<Props, State> {
             Local office numbers:
           </h3>
           <ul className="call__contact__field-office-list">
-            {this.props.currentContact.fieldOffices ? (
-              this.props.currentContact.fieldOffices.map(office => (
+            {this.props.currentContact.field_offices ? (
+              this.props.currentContact.field_offices.map(office => (
                 <li key={office.phone}>
                   {makePhoneLink(office.phone)}
                   {cityFormat(office, this.props.currentContact)}

--- a/src/components/shared/scss/_layout.scss
+++ b/src/components/shared/scss/_layout.scss
@@ -85,8 +85,8 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-top: .8rem;
-    padding-bottom: .8rem;
+    padding-top: 0.8rem;
+    padding-bottom: 0.8rem;
   }
 
   .stars {

--- a/src/components/shared/scss/_location.scss
+++ b/src/components/shared/scss/_location.scss
@@ -1,5 +1,5 @@
 #locationMessage {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 .location {
   @include bp(medium) {


### PR DESCRIPTION
Maybe this got missed in our prettier rework? The name is not cool by tslint standards, but it's in use by all clients so we're just going to make an exception for it at the moment. The field office design still looks good.