### PR TITLE
add blockquote styling, add meta description

### DIFF
--- a/src/components/shared/HeadMeta.tsx
+++ b/src/components/shared/HeadMeta.tsx
@@ -29,6 +29,8 @@ class HeadMeta extends React.Component<Props> {
       <Helmet>
         <title>{pageTitle}</title>
 
+        <meta name="description" content={pageDescription} />
+
         <meta itemProp="name" content={pageTitle} />
         <meta itemProp="description" content={pageDescription} />
         <meta itemProp="image" content={shareImageURL} />

--- a/src/components/shared/scss/_call.scss
+++ b/src/components/shared/scss/_call.scss
@@ -270,6 +270,11 @@
   ul {
     font-size: $font-normal;
   }
+  blockquote {
+    margin-left: 0;
+    border-left: 0.3rem solid $blue;
+    padding-left: 1.2rem;
+  }
 }
 
 .voter {


### PR DESCRIPTION
if you run a lighthouse audit you see we are penalized for not having a standard `meta name="description"`, I don't know too much about seo but I don't think the meta itemprop="description" is a substitute.