### PR TITLE
Fixes the react-snap deployment stuff finally

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -14,7 +14,9 @@ const childProcess = require('child_process');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
-const publicPath = paths.servedPath;
+// react-snap note: forcing this to be 5calls.org breaks any local production build preview
+// because it'll look for hashchunked JS URLs (main.1234abcd.js) that don't exist on prod
+const publicPath = '/'; //paths.servedPath;
 // Some apps do not use client-side routing with pushState.
 // For these, "homepage" can be set to "." to enable relative asset paths.
 const shouldUseRelativeAssetPaths = publicPath === './';

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -16,7 +16,7 @@ const childProcess = require('child_process');
 // It requires a trailing slash, or the file assets will get an incorrect path.
 // react-snap note: forcing this to be 5calls.org breaks any local production build preview
 // because it'll look for hashchunked JS URLs (main.1234abcd.js) that don't exist on prod
-const publicPath = '/'; //paths.servedPath;
+const publicPath = '/';
 // Some apps do not use client-side routing with pushState.
 // For these, "homepage" can be set to "." to enable relative asset paths.
 const shouldUseRelativeAssetPaths = publicPath === './';

--- a/package.json
+++ b/package.json
@@ -187,8 +187,6 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "react-snap": {
-    "concurrency": 1
-  },
+  "react-snap": {},
   "postcss": {}
 }

--- a/package.json
+++ b/package.json
@@ -187,6 +187,5 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "react-snap": {},
   "postcss": {}
 }


### PR DESCRIPTION
...at least it does locally. We'll see what happens in netlify.

Webpack script links were all looking on 5calls.org for hashchunked urls (main.1234abcd.js) which didn't exist. A second deploy would always fix it because after the first deploy the js would then exist in prod.