### PR TITLE
Replace `fregante/setup-git-token` with `setup-git-user`

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -14,18 +14,12 @@ jobs:
       with:
         version: 1.13
     - uses: geertvdc/setup-hub@master # setup running hub cli
-    - uses: actions/checkout@v1 
-    - uses: fregante/setup-git-token@v1 # auth git with github token
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
+    - uses: fregante/setup-git-user@v1 # auth git with github token
     - run: cd tools/archiveSync && go get . && go run main.go
       env:
         FIVECALLS_RDS_URL: ${{ secrets.FIVECALLS_RDS_URL }}
         FIVECALLS_RDS_READ_PASS: ${{ secrets.FIVECALLS_RDS_READ_PASS }}
-    - name: Configure
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
     - name: diff content directory, always succeed so we can test the next step
       run: git diff --quiet archives/content/
     - name: PR if changes exist

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -15,7 +15,7 @@ jobs:
         version: 1.13
     - uses: geertvdc/setup-hub@master # setup running hub cli
     - uses: actions/checkout@v2
-    - uses: fregante/setup-git-user@v1 # auth git with github token
+    - uses: fregante/setup-git-user@v1 # configure git user to enable committing
     - run: cd tools/archiveSync && go get . && go run main.go
       env:
         FIVECALLS_RDS_URL: ${{ secrets.FIVECALLS_RDS_URL }}


### PR DESCRIPTION
In the v2 of `actions/checkout`, setting the token is no longer necessary, so I created a new config-less action to just set the git user: https://github.com/fregante/setup-git-user